### PR TITLE
Add precise mode for Benchmark

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/Benchmark.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/Benchmark.java
@@ -90,6 +90,7 @@ public class Benchmark {
 		Duration monitorDelay = nexmarkConf.get(FlinkNexmarkOptions.METRIC_MONITOR_DELAY);
 		Duration monitorInterval = nexmarkConf.get(FlinkNexmarkOptions.METRIC_MONITOR_INTERVAL);
 		Duration monitorDuration = nexmarkConf.get(FlinkNexmarkOptions.METRIC_MONITOR_DURATION);
+		Boolean monitorMode = nexmarkConf.get(FlinkNexmarkOptions.METRIC_MONITOR_MODE);
 
 		WorkloadSuite workloadSuite = WorkloadSuite.fromConf(nexmarkConf);
 
@@ -106,7 +107,8 @@ public class Benchmark {
 				cpuMetricReceiver,
 				monitorDelay,
 				monitorInterval,
-				monitorDuration);
+				monitorDuration,
+				monitorMode);
 			QueryRunner runner = new QueryRunner(
 				queryName,
 				workload,
@@ -179,7 +181,7 @@ public class Benchmark {
 				entry.getKey(),
 				metric.getPrettyTps(),
 				metric.getPrettyCpu(),
-				metric.getPrettyTpsPerCore());
+				metric.getFormattedTpsPerCore());
 		}
 		printLine('-', "+", itemMaxLength, "", "", "", "");
 		System.err.println();

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/FlinkNexmarkOptions.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/FlinkNexmarkOptions.java
@@ -47,6 +47,11 @@ public class FlinkNexmarkOptions {
 		.defaultValue(Duration.ofSeconds(10))
 		.withDescription("The interval to request the metrics.");
 
+	public static final ConfigOption<Boolean> METRIC_MONITOR_MODE = ConfigOptions
+			.key("nexmark.metric.monitor.precise-mode")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription("Use raw data to record.");
 
 	public static final ConfigOption<String> METRIC_REPORTER_HOST = ConfigOptions
 		.key("nexmark.metric.reporter.host")

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/BenchmarkMetric.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/BenchmarkMetric.java
@@ -27,10 +27,16 @@ import java.util.TreeMap;
 public class BenchmarkMetric {
 	private final double tps;
 	private final double cpu;
+	private final boolean preciseMode;
 
 	public BenchmarkMetric(double tps, double cpu) {
+		this(tps, cpu, false);
+	}
+
+	public BenchmarkMetric(double tps, double cpu, boolean preciseMode) {
 		this.tps = tps;
 		this.cpu = cpu;
+		this.preciseMode = preciseMode;
 	}
 
 	public double getTps() {
@@ -38,7 +44,11 @@ public class BenchmarkMetric {
 	}
 
 	public String getPrettyTps() {
-		return formatLongValue((long) tps);
+		if (preciseMode) {
+			return tps + "";
+		} else {
+			return formatLongValue((long) tps);
+		}
 	}
 
 	public double getCpu() {
@@ -49,9 +59,13 @@ public class BenchmarkMetric {
 		return NUMBER_FORMAT.format(cpu);
 	}
 
-	public String getPrettyTpsPerCore() {
+	public String getFormattedTpsPerCore() {
 		long result = (long) (tps / cpu);
-		return formatLongValue(result);
+		if (preciseMode) {
+			return result + "";
+		} else {
+			return formatLongValue(result);
+		}
 	}
 
 	@Override

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
@@ -47,15 +47,17 @@ public class MetricReporter {
 	private final CpuMetricReceiver cpuMetricReceiver;
 	private final List<BenchmarkMetric> metrics;
 	private final ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
+	private final boolean preciseMode;
 	private volatile Throwable error;
 
-	public MetricReporter(FlinkRestClient flinkRestClient, CpuMetricReceiver cpuMetricReceiver, Duration monitorDelay, Duration monitorInterval, Duration monitorDuration) {
+	public MetricReporter(FlinkRestClient flinkRestClient, CpuMetricReceiver cpuMetricReceiver, Duration monitorDelay, Duration monitorInterval, Duration monitorDuration, Boolean preciseMode) {
 		this.monitorDelay = monitorDelay;
 		this.monitorInterval = monitorInterval;
 		this.monitorDuration = monitorDuration;
 		this.flinkRestClient = flinkRestClient;
 		this.cpuMetricReceiver = cpuMetricReceiver;
 		this.metrics = new ArrayList<>();
+		this.preciseMode = preciseMode;
 	}
 
 	private void submitMonitorThread() {
@@ -138,10 +140,11 @@ public class MetricReporter {
 
 		double avgTps = sumTps / metrics.size();
 		double avgCpu = sumCpu / metrics.size();
-		BenchmarkMetric metric = new BenchmarkMetric(avgTps, avgCpu);
-		String message = String.format("Summary Average: Throughput=%s, Cores=%s",
+		BenchmarkMetric metric = new BenchmarkMetric(avgTps, avgCpu, preciseMode);
+		String message = String.format("Summary Average: Throughput=%s, Cores=%s, Throughput per Cores=%s",
 			metric.getPrettyTps(),
-			metric.getPrettyCpu());
+			metric.getPrettyCpu(),
+			metric.getFormattedTpsPerCore());
 		System.out.println(message);
 		LOG.info(message);
 		return metric;

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/BenchmarkTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/BenchmarkTest.java
@@ -28,23 +28,32 @@ import java.util.LinkedHashMap;
 public class BenchmarkTest {
 
 	@Test
-	public void testPrintSummary() {
+	public void testPrintSummaryInPrettyMode() {
+		testPrintSummary(false);
+	}
+
+	@Test
+	public void testPrintSummaryInPreciseMode() {
+		testPrintSummary(true);
+	}
+
+	private void testPrintSummary(boolean mode) {
 		LinkedHashMap<String, BenchmarkMetric> totalMetrics = new LinkedHashMap<>();
-		totalMetrics.put("q0", new BenchmarkMetric(1, 8.4));
-		totalMetrics.put("q1", new BenchmarkMetric(10, 18.4));
-		totalMetrics.put("q2", new BenchmarkMetric(100.0, 8.4));
-		totalMetrics.put("q3", new BenchmarkMetric(1000.0, 8.4));
-		totalMetrics.put("q4", new BenchmarkMetric(10_000.0, 8.4));
-		totalMetrics.put("q5", new BenchmarkMetric(100_000.0, 8.4));
-		totalMetrics.put("q6", new BenchmarkMetric(1_000_000.0, 8.4));
-		totalMetrics.put("q7", new BenchmarkMetric(10_000_000.0, 8.23));
-		totalMetrics.put("q8", new BenchmarkMetric(100_000_000.0, 8.4));
-		totalMetrics.put("q9", new BenchmarkMetric(1_000_000_000.0, 8.4));
-		totalMetrics.put("q10", new BenchmarkMetric(10_000_000_000.0, 8.4));
-		totalMetrics.put("q11", new BenchmarkMetric(100_000_000_000.0, 8.419));
-		totalMetrics.put("q12", new BenchmarkMetric(100_000_000.0, 8.4));
-		totalMetrics.put("q13", new BenchmarkMetric(10_000_000.0, 8.4));
-		totalMetrics.put("q14", new BenchmarkMetric(1_000_000.0, 8.4));
+		totalMetrics.put("q0", new BenchmarkMetric(1, 8.4, mode));
+		totalMetrics.put("q1", new BenchmarkMetric(10, 18.4, mode));
+		totalMetrics.put("q2", new BenchmarkMetric(100.0, 8.4, mode));
+		totalMetrics.put("q3", new BenchmarkMetric(1000.0, 8.4, mode));
+		totalMetrics.put("q4", new BenchmarkMetric(10_000.0, 8.4, mode));
+		totalMetrics.put("q5", new BenchmarkMetric(100_000.0, 8.4, mode));
+		totalMetrics.put("q6", new BenchmarkMetric(1_000_000.0, 8.4, mode));
+		totalMetrics.put("q7", new BenchmarkMetric(10_000_000.0, 8.23, mode));
+		totalMetrics.put("q8", new BenchmarkMetric(100_000_000.0, 8.4, mode));
+		totalMetrics.put("q9", new BenchmarkMetric(1_000_000_000.0, 8.4, mode));
+		totalMetrics.put("q10", new BenchmarkMetric(10_000_000_000.0, 8.4, mode));
+		totalMetrics.put("q11", new BenchmarkMetric(100_000_000_000.0, 8.419, mode));
+		totalMetrics.put("q12", new BenchmarkMetric(100_000_000.0, 8.4, mode));
+		totalMetrics.put("q13", new BenchmarkMetric(10_000_000.0, 8.4, mode));
+		totalMetrics.put("q14", new BenchmarkMetric(1_000_000.0, 8.4, mode));
 		Benchmark.printSummary(totalMetrics);
 	}
 


### PR DESCRIPTION
Motivation:
   Report raw data in precise mode, which is useful for comparing between different versions.

Modification:
  1. it use raw data when reporting
  2. it report throughput/cores in every quires report. It's useful when  benchmark exits unexpectedly. 