### PR TITLE
Add options to generate the extended bid

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java
@@ -138,6 +138,12 @@ public class NexmarkConfiguration implements Serializable {
 	/** Flag to determine whether to use extended bid as output. **/
 	@JsonProperty public boolean extendedBidMode = false;
 
+	/**
+	 * Keep the number of categories small so the example queries will find results even with a small
+	 * batch of events.
+	 */
+	@JsonProperty public int numCategories = 5;
+
 	/** Base time for first event. If value is 0, use currentTime. **/
 	@JsonProperty public long baseTime = System.currentTimeMillis();
 
@@ -188,6 +194,7 @@ public class NexmarkConfiguration implements Serializable {
 			rateUnit == that.rateUnit &&
 			baseTime == that.baseTime &&
 			extendedBidMode == that.extendedBidMode &&
+			numCategories == that.numCategories &&
 			simulationMode == that.simulationMode;
 	}
 
@@ -224,6 +231,7 @@ public class NexmarkConfiguration implements Serializable {
 			outOfOrderGroupSize,
 			baseTime,
 			extendedBidMode,
+			numCategories,
 			simulationMode);
 	}
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java
@@ -135,6 +135,14 @@ public class NexmarkConfiguration implements Serializable {
 	 */
 	@JsonProperty public long outOfOrderGroupSize = 1;
 
+	/** Flag to determine whether to use extended bid as output. **/
+	@JsonProperty public boolean extendedBidMode = false;
+
+	/** Base time for first event. If value is 0, use currentTime. **/
+	@JsonProperty public long baseTime = System.currentTimeMillis();
+
+	@JsonProperty public boolean simulationMode = true;
+
 	/** Return full description as a string. */
 	@Override
 	public String toString() {
@@ -177,7 +185,10 @@ public class NexmarkConfiguration implements Serializable {
 			Double.compare(that.probDelayedEvent, probDelayedEvent) == 0 &&
 			outOfOrderGroupSize == that.outOfOrderGroupSize &&
 			rateShape == that.rateShape &&
-			rateUnit == that.rateUnit;
+			rateUnit == that.rateUnit &&
+			baseTime == that.baseTime &&
+			extendedBidMode == that.extendedBidMode &&
+			simulationMode == that.simulationMode;
 	}
 
 	@Override
@@ -210,6 +221,9 @@ public class NexmarkConfiguration implements Serializable {
 			numActivePeople,
 			occasionalDelaySec,
 			probDelayedEvent,
-			outOfOrderGroupSize);
+			outOfOrderGroupSize,
+			baseTime,
+			extendedBidMode,
+			simulationMode);
 	}
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/GeneratorConfig.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/GeneratorConfig.java
@@ -83,6 +83,8 @@ public class GeneratorConfig implements Serializable {
    */
   private final long eventsPerEpoch;
 
+  private final int numCategories;
+
   public GeneratorConfig(
       NexmarkConfiguration configuration,
       long firstEventId,
@@ -117,6 +119,7 @@ public class GeneratorConfig implements Serializable {
     long epochPeriodMs = 0;
     this.eventsPerEpoch = eventsPerEpoch;
     this.epochPeriodMs = epochPeriodMs;
+    this.numCategories = configuration.numCategories;
   }
 
   /** Return a copy of this config. */
@@ -175,6 +178,10 @@ public class GeneratorConfig implements Serializable {
 
   public int getNumActivePeople() {
     return configuration.numActivePeople;
+  }
+
+  public int getNumCategories() {
+    return configuration.numCategories;
   }
 
   public int getHotSellersRatio() {
@@ -288,6 +295,7 @@ public class GeneratorConfig implements Serializable {
         firstEventNumber == that.firstEventNumber &&
         epochPeriodMs == that.epochPeriodMs &&
         eventsPerEpoch == that.eventsPerEpoch &&
+        numCategories == that.numCategories &&
         Objects.equals(configuration, that.configuration) &&
         Arrays.equals(interEventDelayUs, that.interEventDelayUs);
   }
@@ -305,6 +313,7 @@ public class GeneratorConfig implements Serializable {
         maxEvents,
         firstEventNumber,
         epochPeriodMs,
+        numCategories,
         eventsPerEpoch);
     result = 31 * result + Arrays.hashCode(interEventDelayUs);
     return result;
@@ -336,6 +345,8 @@ public class GeneratorConfig implements Serializable {
     sb.append(epochPeriodMs);
     sb.append(";eventsPerEpoch:");
     sb.append(eventsPerEpoch);
+    sb.append(";numCategories:");
+    sb.append(numCategories);
     sb.append("}");
     return sb.toString();
   }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
@@ -186,7 +186,7 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
     // the event timestamp.
     long watermark = config.timestampForEvent(config.nextEventNumberForWatermark(eventsCountSoFar));
     // When, in wallclock time, we should emit the event.
-    long wallclockTimestamp = wallclockBaseTime + (eventTimestamp - getCurrentConfig().baseTime);
+    long wallclockTimestamp = wallclockBaseTime + (eventTimestamp - getCurrentConfig().getBaseTime());
 
     // Seed the random number generator with the next 'event id'.
     Random random = new Random(getNextEventId());

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
@@ -113,6 +113,8 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
   /** Wallclock time at which we emitted the first event (ms since epoch). Initially -1. */
   private long wallclockBaseTime;
 
+  private Random random = new Random();
+
   public NexmarkGenerator(GeneratorConfig config, long eventsCountSoFar, long wallclockBaseTime) {
     checkNotNull(config);
     this.config = config;
@@ -187,9 +189,6 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
     long watermark = config.timestampForEvent(config.nextEventNumberForWatermark(eventsCountSoFar));
     // When, in wallclock time, we should emit the event.
     long wallclockTimestamp = wallclockBaseTime + (eventTimestamp - getCurrentConfig().getBaseTime());
-
-    // Seed the random number generator with the next 'event id'.
-    Random random = new Random(getNextEventId());
 
     long newEventId = getNextEventId();
     long rem = newEventId % config.totalProportion;

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java
@@ -25,11 +25,6 @@ import java.util.Random;
 
 /** AuctionGenerator. */
 public class AuctionGenerator {
-  /**
-   * Keep the number of categories small so the example queries will find results even with a small
-   * batch of events.
-   */
-  private static final int NUM_CATEGORIES = 5;
 
   /** Number of yet-to-be-created people and auction ids allowed. */
   private static final int AUCTION_ID_LEAD = 10;
@@ -49,10 +44,10 @@ public class AuctionGenerator {
     long seller, category;
     if (config.getExtendedBidMode()) {
       seller = nextSellerIdWithoutRandom(config, id);
-      category = nextCategoryWithoutRandom(id);
+      category = nextCategoryWithoutRandom(id, config.getNumCategories());
     } else {
       seller = nextSellerIdWithRandom(config, random, eventId);
-      category = nextCategoryWithRandom(random);
+      category = nextCategoryWithRandom(random, config.getNumCategories());
     }
     seller += GeneratorConfig.FIRST_PERSON_ID;
 
@@ -161,14 +156,19 @@ public class AuctionGenerator {
   /**
    * Generate the category information.
    */
-  public static long nextCategoryWithRandom(Random random) {
-    return GeneratorConfig.FIRST_CATEGORY_ID + random.nextInt(NUM_CATEGORIES);
+  public static long nextCategoryWithRandom(Random random, int numCategories) {
+    return GeneratorConfig.FIRST_CATEGORY_ID + random.nextInt(numCategories);
   }
 
   /**
    * Generate the category information with auction id. In most cases, it's used to look up the category.
    */
-  public static long nextCategoryWithoutRandom(long auctionId) {
-    return GeneratorConfig.FIRST_CATEGORY_ID + auctionId % NUM_CATEGORIES;
+  public static long nextCategoryWithoutRandom(long auctionId, int numCategories) {
+    return GeneratorConfig.FIRST_CATEGORY_ID + hashLong(auctionId) % numCategories;
+  }
+
+  private static long hashLong(long key) {
+    long h = key * 0x9E3779B9L;
+    return Integer.toUnsignedLong((int) (h ^ (h >> 32)));
   }
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java
@@ -46,17 +46,16 @@ public class AuctionGenerator {
 
     long id = lastBase0AuctionId(config, eventId) + GeneratorConfig.FIRST_AUCTION_ID;
 
-    long seller;
-    // Here P(auction will be for a hot seller) = 1 - 1/hotSellersRatio.
-    if (random.nextInt(config.getHotSellersRatio()) > 0) {
-      // Choose the first person in the batch of last HOT_SELLER_RATIO people.
-      seller = (PersonGenerator.lastBase0PersonId(config, eventId) / HOT_SELLER_RATIO) * HOT_SELLER_RATIO;
+    long seller, category;
+    if (config.getExtendedBidMode()) {
+      seller = nextSellerIdWithoutRandom(config, id);
+      category = nextCategoryWithoutRandom(id);
     } else {
-      seller = PersonGenerator.nextBase0PersonId(eventId, random, config);
+      seller = nextSellerIdWithRandom(config, random, eventId);
+      category = nextCategoryWithRandom(random);
     }
     seller += GeneratorConfig.FIRST_PERSON_ID;
 
-    long category = GeneratorConfig.FIRST_CATEGORY_ID + random.nextInt(NUM_CATEGORIES);
     long initialBid = PriceGenerator.nextPrice(random);
     long expires = timestamp + nextAuctionLengthMs(eventsCountSoFar, random, timestamp, config);
     String name = StringsGenerator.nextString(random, 20);
@@ -130,5 +129,46 @@ public class AuctionGenerator {
     // Choose a length with average horizonMs.
     long horizonMs = futureAuction - timestamp;
     return 1L + LongGenerator.nextLong(random, Math.max(horizonMs * 2, 1L));
+  }
+
+  /**
+   * Generate the seller id.
+   */
+  public static long nextSellerIdWithRandom(GeneratorConfig config, Random random, long eventId) {
+    // Here P(auction will be for a hot seller) = 1 - 1/hotSellersRatio.
+    if (random.nextInt(config.getHotSellersRatio()) > 0) {
+      // Choose the first person in the batch of last HOT_SELLER_RATIO people.
+      return (PersonGenerator.lastBase0PersonId(config, eventId) / HOT_SELLER_RATIO) * HOT_SELLER_RATIO;
+    } else {
+      return PersonGenerator.nextBase0PersonId(eventId, random, config);
+    }
+  }
+
+  /**
+   * Generate the seller id.
+   *
+   * It only used when generate extended bid.
+   */
+  public static long nextSellerIdWithoutRandom(GeneratorConfig config, long auctionId) {
+    // Here P(auction will be for a hot seller) = 1 - 1/hotSellersRatio.
+    if (auctionId % config.getHotAuctionRatio() > 0) {
+      return (PersonGenerator.lastBase0PersonIdWithAuctionId(config, auctionId) / HOT_SELLER_RATIO) * HOT_SELLER_RATIO;
+    } else {
+      return PersonGenerator.nextBase0PersonIdWithAuctionId(config, auctionId);
+    }
+  }
+
+  /**
+   * Generate the category information.
+   */
+  public static long nextCategoryWithRandom(Random random) {
+    return GeneratorConfig.FIRST_CATEGORY_ID + random.nextInt(NUM_CATEGORIES);
+  }
+
+  /**
+   * Generate the category information with auction id. In most cases, it's used to look up the category.
+   */
+  public static long nextCategoryWithoutRandom(long auctionId) {
+    return GeneratorConfig.FIRST_CATEGORY_ID + auctionId % NUM_CATEGORIES;
   }
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
@@ -64,7 +64,7 @@ public class BidGenerator {
     int currentSize = 8 + 8 + 8 + 8;
     if (config.getExtendedBidMode()) {
       currentSize += (8 + 8);
-      String extra = StringsGenerator.nextExtra(random, currentSize, config.getAvgAuctionByteSize());
+      String extra = StringsGenerator.nextExtra(random, currentSize, config.getAvgBidByteSize());
       return new ExtendedBid(
               auction,
               AuctionGenerator.nextSellerIdWithoutRandom(config, auction),

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
@@ -69,7 +69,7 @@ public class BidGenerator {
               auction,
               AuctionGenerator.nextSellerIdWithoutRandom(config, auction),
               bidder,
-              AuctionGenerator.nextCategoryWithoutRandom(auction),
+              AuctionGenerator.nextCategoryWithoutRandom(auction, config.getNumCategories()),
               price,
               Instant.ofEpochMilli(timestamp),
               extra);

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
@@ -19,6 +19,7 @@ package com.github.nexmark.flink.generator.model;
 
 import com.github.nexmark.flink.generator.GeneratorConfig;
 import com.github.nexmark.flink.model.Bid;
+import com.github.nexmark.flink.model.ExtendedBid;
 
 import java.time.Instant;
 import java.util.Random;
@@ -59,8 +60,22 @@ public class BidGenerator {
     bidder += GeneratorConfig.FIRST_PERSON_ID;
 
     long price = PriceGenerator.nextPrice(random);
+
     int currentSize = 8 + 8 + 8 + 8;
-    String extra = StringsGenerator.nextExtra(random, currentSize, config.getAvgBidByteSize());
-    return new Bid(auction, bidder, price, Instant.ofEpochMilli(timestamp), extra);
+    if (config.getExtendedBidMode()) {
+      currentSize += (8 + 8);
+      String extra = StringsGenerator.nextExtra(random, currentSize, config.getAvgAuctionByteSize());
+      return new ExtendedBid(
+              auction,
+              AuctionGenerator.nextSellerIdWithoutRandom(config, auction),
+              bidder,
+              AuctionGenerator.nextCategoryWithoutRandom(auction),
+              price,
+              Instant.ofEpochMilli(timestamp),
+              extra);
+    } else {
+      String extra = StringsGenerator.nextExtra(random, currentSize, config.getAvgBidByteSize());
+      return new Bid(auction, bidder, price, Instant.ofEpochMilli(timestamp), extra);
+    }
   }
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/PersonGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/PersonGenerator.java
@@ -95,6 +95,32 @@ public class PersonGenerator {
     return epoch * config.personProportion + offset;
   }
 
+  /**
+   * Return the person id with specified auction id. It is used to generate the seller id or use auction id to
+   * look up the seller id.
+   *
+   * Note: it only uses the generated person as seller.
+   */
+  public static long lastBase0PersonIdWithAuctionId(GeneratorConfig config, long auctionId) {
+    long epoch = auctionId / config.auctionProportion;
+    long offset = auctionId % config.auctionProportion;
+
+    return epoch * config.personProportion + (offset % config.personProportion);
+  }
+
+  /**
+   * Return the person id with specified auction id. It is used to generate the seller id or use auction id to
+   * look up the seller id.
+   *
+   * Note: it may use the person who has not generated.
+   */
+  public static long nextBase0PersonIdWithAuctionId(GeneratorConfig config, long auctionId) {
+    long numPeople = (auctionId / config.auctionProportion + 1) * config.personProportion;
+    long activePeople = Math.min(numPeople, config.getNumActivePeople());
+    long n = auctionId % (activePeople + PERSON_ID_LEAD);
+    return numPeople - activePeople + n;
+  }
+
   /** return a random US state. */
   private static String nextUSState(Random random) {
     return US_STATES.get(random.nextInt(US_STATES.size()));

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/cpu/CpuMetricReceiver.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/cpu/CpuMetricReceiver.java
@@ -60,7 +60,7 @@ public class CpuMetricReceiver implements Closeable {
 			InetAddress address = InetAddress.getByName(host);
 			server = new ServerSocket(port, 10, address);
 		} catch (IOException e) {
-			throw new RuntimeException("Could not open socket to receive back cpu metrics.");
+			throw new RuntimeException("Could not open socket to receive back cpu metrics.", e);
 		}
 	}
 

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/model/ExtendedBid.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/model/ExtendedBid.java
@@ -1,0 +1,58 @@
+package com.github.nexmark.flink.model;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.github.nexmark.flink.utils.NexmarkUtils;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** A extended bid for an item on auction. It also contains the seller and category information. */
+public class ExtendedBid extends Bid {
+
+	/** The seller id that binds with auction. */
+	@JsonProperty public long seller;
+
+	/** The category of the auction. */
+	@JsonProperty public long category;
+
+	public ExtendedBid(long auction, long seller, long bidder, long category, long price, Instant dateTime, String extra) {
+		super(auction, bidder, price, dateTime, extra);
+		this.seller = seller;
+		this.category = category;
+	}
+
+	@Override
+	public boolean equals(Object otherObject) {
+		if (this == otherObject) {
+			return true;
+		}
+		if (otherObject == null || getClass() != otherObject.getClass()) {
+			return false;
+		}
+
+		ExtendedBid other = (ExtendedBid) otherObject;
+		return Objects.equals(auction, other.auction)
+			&& Objects.equals(bidder, other.bidder)
+			&& Objects.equals(price, other.price)
+			&& Objects.equals(dateTime, other.dateTime)
+			&& Objects.equals(extra, other.extra)
+			&& Objects.equals(seller, other.seller)
+			&& Objects.equals(category, other.category);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(auction, seller, bidder, category, price, dateTime, extra);
+	}
+
+	@Override
+	public String toString() {
+		try {
+			return NexmarkUtils.MAPPER.writeValueAsString(this);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkSourceOptions.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkSourceOptions.java
@@ -159,6 +159,14 @@ public class NexmarkSourceOptions {
 		.defaultValue(false);
 
 	/**
+	 * @see NexmarkConfiguration#numCategories
+	 */
+	public static final ConfigOption<Integer> NUM_CATEGORIES = ConfigOptions
+			.key("num.categories")
+			.intType()
+			.defaultValue(5);
+
+	/**
 	 * @see NexmarkConfiguration#baseTime
 	 */
 	public static final ConfigOption<Long> BASE_TIME = ConfigOptions
@@ -189,6 +197,7 @@ public class NexmarkSourceOptions {
 		nexmarkConf.hotSellersRatio = config.get(AUCTION_HOT_RATIO_SELLERS);
 		nexmarkConf.numEvents = config.get(EVENTS_NUM);
 		nexmarkConf.extendedBidMode = config.get(EXTENDED_BID_MODE);
+		nexmarkConf.numCategories = config.get(NUM_CATEGORIES);
 		config.getOptional(BASE_TIME).ifPresent(timestamp -> nexmarkConf.baseTime = timestamp);
 		nexmarkConf.simulationMode = config.get(SIMULATION_MODE);
 

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkSourceOptions.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkSourceOptions.java
@@ -150,6 +150,26 @@ public class NexmarkSourceOptions {
 		.longType()
 		.defaultValue(0L);
 
+	/**
+	 * @see NexmarkConfiguration#extendedBidMode
+	 */
+	public static final ConfigOption<Boolean> EXTENDED_BID_MODE = ConfigOptions
+		.key("bid.extended.mode")
+		.booleanType()
+		.defaultValue(false);
+
+	/**
+	 * @see NexmarkConfiguration#baseTime
+	 */
+	public static final ConfigOption<Long> BASE_TIME = ConfigOptions
+		.key("events.base-time")
+		.longType()
+		.noDefaultValue();
+
+	public static final ConfigOption<Boolean> SIMULATION_MODE = ConfigOptions
+		.key("events.simulation.mode")
+		.booleanType()
+		.defaultValue(true);
 
 	public static NexmarkConfiguration convertToNexmarkConfiguration(ReadableConfig config) {
 		NexmarkConfiguration nexmarkConf = new NexmarkConfiguration();
@@ -168,6 +188,9 @@ public class NexmarkSourceOptions {
 		nexmarkConf.hotBiddersRatio = config.get(BID_HOT_RATIO_BIDDERS);
 		nexmarkConf.hotSellersRatio = config.get(AUCTION_HOT_RATIO_SELLERS);
 		nexmarkConf.numEvents = config.get(EVENTS_NUM);
+		nexmarkConf.extendedBidMode = config.get(EXTENDED_BID_MODE);
+		config.getOptional(BASE_TIME).ifPresent(timestamp -> nexmarkConf.baseTime = timestamp);
+		nexmarkConf.simulationMode = config.get(SIMULATION_MODE);
 
 		return nexmarkConf;
 	}

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSourceFactory.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSourceFactory.java
@@ -42,14 +42,16 @@ public class NexmarkTableSourceFactory implements DynamicTableSourceFactory {
 		final ReadableConfig config = helper.getOptions();
 		helper.validate();
 		// validate schema
-		validateSchema(TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema()));
+		validateSchema(TableSchemaUtils.getPhysicalSchema(
+				context.getCatalogTable().getSchema()),
+				config.get(NexmarkSourceOptions.EXTENDED_BID_MODE));
 
 		int parallelism = context.getConfiguration().get(CoreOptions.DEFAULT_PARALLELISM);
 		NexmarkConfiguration nexmarkConf = NexmarkSourceOptions.convertToNexmarkConfiguration(config);
 		nexmarkConf.numEventGenerators = parallelism;
+
 		GeneratorConfig generatorConfig = new GeneratorConfig(
 			nexmarkConf,
-			System.currentTimeMillis(),
 			1,
 			nexmarkConf.numEvents,
 			1);
@@ -57,11 +59,12 @@ public class NexmarkTableSourceFactory implements DynamicTableSourceFactory {
 		return new NexmarkTableSource(generatorConfig);
 	}
 
-	private void validateSchema(TableSchema schema) {
-		if (!schema.equals(NexmarkTableSource.NEXMARK_SCHEMA)) {
+	private void validateSchema(TableSchema schema, boolean extendedMode) {
+		TableSchema targetSchema = extendedMode? NexmarkTableSource.EXTENDED_NEXMARK_SCHEMA : NexmarkTableSource.NEXMARK_SCHEMA;
+		if (!schema.equals(targetSchema)) {
 			throw new IllegalArgumentException(
 				String.format("The nexmark source table must be in the schema of \n%s\n. However, It is \n%s\n",
-					NexmarkTableSource.NEXMARK_SCHEMA,
+					targetSchema,
 					schema));
 		}
 	}
@@ -94,6 +97,9 @@ public class NexmarkTableSourceFactory implements DynamicTableSourceFactory {
 		sets.add(NexmarkSourceOptions.BID_HOT_RATIO_BIDDERS);
 		sets.add(NexmarkSourceOptions.AUCTION_HOT_RATIO_SELLERS);
 		sets.add(NexmarkSourceOptions.EVENTS_NUM);
+		sets.add(NexmarkSourceOptions.BASE_TIME);
+		sets.add(NexmarkSourceOptions.EXTENDED_BID_MODE);
+		sets.add(NexmarkSourceOptions.SIMULATION_MODE);
 		return sets;
 	}
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSourceFactory.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSourceFactory.java
@@ -100,6 +100,7 @@ public class NexmarkTableSourceFactory implements DynamicTableSourceFactory {
 		sets.add(NexmarkSourceOptions.BASE_TIME);
 		sets.add(NexmarkSourceOptions.EXTENDED_BID_MODE);
 		sets.add(NexmarkSourceOptions.SIMULATION_MODE);
+		sets.add(NexmarkSourceOptions.NUM_CATEGORIES);
 		return sets;
 	}
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/RowDataEventDeserializer.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/RowDataEventDeserializer.java
@@ -26,9 +26,16 @@ import org.apache.flink.table.data.TimestampData;
 import com.github.nexmark.flink.model.Auction;
 import com.github.nexmark.flink.model.Bid;
 import com.github.nexmark.flink.model.Event;
+import com.github.nexmark.flink.model.ExtendedBid;
 import com.github.nexmark.flink.model.Person;
 
 public class RowDataEventDeserializer implements EventDeserializer<RowData> {
+
+	private boolean extendedBidMode;
+
+	public RowDataEventDeserializer(boolean extendedBidMode) {
+		this.extendedBidMode = extendedBidMode;
+	}
 
 	@Override
 	public RowData deserialize(Event event) {
@@ -82,12 +89,26 @@ public class RowDataEventDeserializer implements EventDeserializer<RowData> {
 	}
 
 	private RowData convertBid(Bid bid) {
-		GenericRowData rowData = new GenericRowData(5);
-		rowData.setField(0, bid.auction);
-		rowData.setField(1, bid.bidder);
-		rowData.setField(2, bid.price);
-		rowData.setField(3, TimestampData.fromInstant(bid.dateTime));
-		rowData.setField(4, StringData.fromString(bid.extra));
+		GenericRowData rowData;
+		if (extendedBidMode) {
+			ExtendedBid extendedBid = (ExtendedBid) bid;
+			rowData = new GenericRowData(7);
+			rowData.setField(0, extendedBid.auction);
+			rowData.setField(1, extendedBid.seller);
+			rowData.setField(2, extendedBid.bidder);
+			rowData.setField(3, extendedBid.category);
+			rowData.setField(4, bid.price);
+			rowData.setField(5, TimestampData.fromInstant(bid.dateTime));
+			rowData.setField(6, StringData.fromString(bid.extra));
+		} else {
+			rowData = new GenericRowData(5);
+			rowData.setField(0, bid.auction);
+			rowData.setField(1, bid.bidder);
+			rowData.setField(2, bid.price);
+			rowData.setField(3, TimestampData.fromInstant(bid.dateTime));
+			rowData.setField(4, StringData.fromString(bid.extra));
+		}
+
 		return rowData;
 	}
 

--- a/nexmark-flink/src/main/resources/conf/nexmark.yaml
+++ b/nexmark-flink/src/main/resources/conf/nexmark.yaml
@@ -34,7 +34,7 @@ nexmark.metric.reporter.port: 9098
 #==============================================================================
 
 nexmark.workload.suite.10m.tps: 10000000
-nexmark.workload.suite.10m.queries: "q0,q1,q2,q3,q4,q5,q7,q8,q9,q10,q11,q12,q13,q14,q15"
+nexmark.workload.suite.10m.queries: "q0,q1,q2,q3,q4,q5,q7,q8,q9,q10,q11,q12,q13,q14,q15,q16,q17,q18"
 
 # Set different workload for group of queries
 

--- a/nexmark-flink/src/main/resources/queries/ddl.sql
+++ b/nexmark-flink/src/main/resources/queries/ddl.sql
@@ -22,7 +22,9 @@ CREATE TABLE nexmark (
         extra  VARCHAR>,
     bid ROW<
         auction  BIGINT,
+        seller BIGINT,
         bidder  BIGINT,
+        category BIGINT,
         price  BIGINT,
         dateTime  TIMESTAMP(3),
         extra  VARCHAR>,
@@ -39,7 +41,9 @@ CREATE TABLE nexmark (
     'next-event.rate' = '${TPS}',
     'person.proportion' = '${PERSON_PROPORTION}',
     'auction.proportion' = '${AUCTION_PROPORTION}',
-    'bid.proportion' = '${BID_PROPORTION}'
+    'bid.proportion' = '${BID_PROPORTION}',
+    'bid.extended.mode' = 'true',
+    'num.categories' = '10000'
 );
 
 CREATE VIEW person AS
@@ -71,7 +75,9 @@ FROM nexmark WHERE event_type = 1;
 CREATE VIEW bid AS
 SELECT
     bid.auction,
+    bid.seller,
     bid.bidder,
+    bid.category,
     bid.price,
     dateTime,
     bid.extra

--- a/nexmark-flink/src/main/resources/queries/q16.sql
+++ b/nexmark-flink/src/main/resources/queries/q16.sql
@@ -1,0 +1,36 @@
+-- -------------------------------------------------------------------------------------------------
+-- Query 16: Bidding Statistics Report (Not in original suite)
+-- -------------------------------------------------------------------------------------------------
+-- How many distinct users join the bidding for different level of price?
+-- Illustrates multiple distinct aggregations with filters.
+-- -------------------------------------------------------------------------------------------------
+
+CREATE TABLE discard_sink (
+  category BIGINT,
+  `day` VARCHAR,
+  total_bids BIGINT,
+  rank1_bids BIGINT,
+  rank2_bids BIGINT,
+  rank3_bids BIGINT,
+  total_bidders BIGINT,
+  rank1_bidders BIGINT,
+  rank2_bidders BIGINT,
+  rank3_bidders BIGINT
+) WITH (
+  'connector' = 'blackhole'
+);
+
+INSERT INTO discard_sink
+SELECT
+     category,
+     DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+     count(*) AS total_bids,
+     count(*) filter (where price < 10000) AS rank1_bids,
+     count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
+     count(*) filter (where price >= 1000000) AS rank3_bids,
+     count(distinct bidder) AS total_bidders,
+     count(distinct bidder) filter (where price < 10000) AS rank1_bidders,
+     count(distinct bidder) filter (where price >= 10000 and price < 1000000) AS rank2_bidders,
+     count(distinct bidder) filter (where price >= 1000000) AS rank3_bidders
+FROM bid
+GROUP BY category, DATE_FORMAT(dateTime, 'yyyy-MM-dd');

--- a/nexmark-flink/src/main/resources/queries/q17.sql
+++ b/nexmark-flink/src/main/resources/queries/q17.sql
@@ -1,0 +1,38 @@
+-- -------------------------------------------------------------------------------------------------
+-- Query 16: Bidding Statistics Report (Not in original suite)
+-- -------------------------------------------------------------------------------------------------
+-- How many distinct users join the bidding for different level of price?
+-- Illustrates multiple distinct aggregations with filters.
+-- -------------------------------------------------------------------------------------------------
+
+CREATE TABLE discard_sink (
+  category BIGINT,
+  `day` VARCHAR,
+  `hour` VARCHAR,
+  total_bids BIGINT,
+  rank1_bids BIGINT,
+  rank2_bids BIGINT,
+  rank3_bids BIGINT,
+  total_bidders BIGINT,
+  rank1_bidders BIGINT,
+  rank2_bidders BIGINT,
+  rank3_bidders BIGINT
+) WITH (
+  'connector' = 'blackhole'
+);
+
+INSERT INTO discard_sink
+SELECT
+     category,
+     DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+     DATE_FORMAT(dateTime, 'HH') as `hour`,
+     count(*) AS total_bids,
+     count(*) filter (where price < 10000) AS rank1_bids,
+     count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
+     count(*) filter (where price >= 1000000) AS rank3_bids,
+     count(distinct bidder) AS total_bidders,
+     count(distinct bidder) filter (where price < 10000) AS rank1_bidders,
+     count(distinct bidder) filter (where price >= 10000 and price < 1000000) AS rank2_bidders,
+     count(distinct bidder) filter (where price >= 1000000) AS rank3_bidders
+FROM bid
+GROUP BY category, DATE_FORMAT(dateTime, 'yyyy-MM-dd'), DATE_FORMAT(dateTime, 'HH');

--- a/nexmark-flink/src/main/resources/queries/q18.sql
+++ b/nexmark-flink/src/main/resources/queries/q18.sql
@@ -1,0 +1,28 @@
+-- -------------------------------------------------------------------------------------------------
+-- Query 16: Bidding Statistics Report (Not in original suite)
+-- -------------------------------------------------------------------------------------------------
+-- How many distinct users join the bidding for different level of price?
+-- Illustrates multiple distinct aggregations with filters.
+-- -------------------------------------------------------------------------------------------------
+
+CREATE TABLE discard_sink (
+  category BIGINT,
+  `day` VARCHAR,
+  bidder BIGINT,
+  min_visit_time1 BIGINT,
+  min_visit_time2 BIGINT,
+  min_visit_time3 BIGINT
+) WITH (
+  'connector' = 'blackhole'
+);
+
+INSERT INTO discard_sink
+SELECT
+     category,
+     DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+     bidder,
+     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price < 10000) AS min_visit_time1,
+     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price >= 10000 and price < 1000000) AS min_visit_time2,
+     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price >= 1000000) AS min_visit_time3
+FROM bid
+GROUP BY category, DATE_FORMAT(dateTime, 'yyyy-MM-dd'), bidder;

--- a/nexmark-flink/src/main/resources/queries/q18.sql
+++ b/nexmark-flink/src/main/resources/queries/q18.sql
@@ -21,8 +21,8 @@ SELECT
      category,
      DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
      bidder,
-     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price < 10000) AS min_visit_time1,
-     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price >= 10000 and price < 1000000) AS min_visit_time2,
-     MIN(UNIX_TIMESTAMP(dateTime)) filter (where price >= 1000000) AS min_visit_time3
+     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price < 10000) AS min_visit_time1,
+     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price >= 10000 and price < 1000000) AS min_visit_time2,
+     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price >= 1000000) AS min_visit_time3
 FROM bid
 GROUP BY category, DATE_FORMAT(dateTime, 'yyyy-MM-dd'), bidder;

--- a/nexmark-flink/src/main/resources/queries/q18.sql
+++ b/nexmark-flink/src/main/resources/queries/q18.sql
@@ -21,8 +21,8 @@ SELECT
      category,
      DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
      bidder,
-     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price < 10000) AS min_visit_time1,
-     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price >= 10000 and price < 1000000) AS min_visit_time2,
-     MIN(UNIX_TIMESTAMP(CAST(dateTime AS VARCHAR))) filter (where price >= 1000000) AS min_visit_time3
+     MIN(UNIX_TIMESTAMP(DATE_FORMAT(dateTime, 'yyyy-MM-dd HH:mm:ss'))) filter (where price < 10000) AS min_visit_time1,
+     MIN(UNIX_TIMESTAMP(DATE_FORMAT(dateTime, 'yyyy-MM-dd HH:mm:ss'))) filter (where price >= 10000 and price < 1000000) AS min_visit_time2,
+     MIN(UNIX_TIMESTAMP(DATE_FORMAT(dateTime, 'yyyy-MM-dd HH:mm:ss'))) filter (where price >= 1000000) AS min_visit_time3
 FROM bid
 GROUP BY category, DATE_FORMAT(dateTime, 'yyyy-MM-dd'), bidder;

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
@@ -21,15 +21,30 @@ package com.github.nexmark.flink.generator;
 import com.github.nexmark.flink.NexmarkConfiguration;
 import com.github.nexmark.flink.model.Event;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class NexmarkGeneratorTest {
+
+	@Parameterized.Parameter(0)
+	public boolean useExtendedBidMode;
+
+	@Parameterized.Parameters(name = "useExtendedBidMode = {0}")
+	public static Object[] parameters() {
+		return new Object[][] {
+				new Object[] {true},
+				new Object[] {false}
+		};
+	}
 
 	@Test
 	public void testGenerate() {
 		NexmarkConfiguration nexmarkConfiguration = new NexmarkConfiguration();
 		nexmarkConfiguration.bidProportion = 46;
+		nexmarkConfiguration.extendedBidMode = useExtendedBidMode;
 		GeneratorConfig generatorConfig = new GeneratorConfig(
-			nexmarkConfiguration, System.currentTimeMillis(), 1, 100, 1);
+			nexmarkConfiguration, 0, 15000, 0);
 		NexmarkGenerator generator = new NexmarkGenerator(generatorConfig);
 		int count = 0;
 		while (generator.hasNext()) {

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
@@ -43,6 +43,7 @@ public class NexmarkGeneratorTest {
 		NexmarkConfiguration nexmarkConfiguration = new NexmarkConfiguration();
 		nexmarkConfiguration.bidProportion = 46;
 		nexmarkConfiguration.extendedBidMode = useExtendedBidMode;
+		nexmarkConfiguration.numCategories = 10_000;
 		GeneratorConfig generatorConfig = new GeneratorConfig(
 			nexmarkConfiguration, 0, 15000, 0);
 		NexmarkGenerator generator = new NexmarkGenerator(generatorConfig);

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkSourceFunctionITCase.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkSourceFunctionITCase.java
@@ -35,7 +35,7 @@ public class NexmarkSourceFunctionITCase {
 		NexmarkConfiguration nexmarkConfiguration = new NexmarkConfiguration();
 		nexmarkConfiguration.bidProportion = 46;
 		GeneratorConfig generatorConfig = new GeneratorConfig(
-			nexmarkConfiguration, System.currentTimeMillis(), 1, 100, 1);
+			nexmarkConfiguration,1, 100, 1);
 		env.addSource(new NexmarkSourceFunction<>(
 				generatorConfig,
 				(EventDeserializer<String>) Event::toString,

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkTableSourceFactoryTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkTableSourceFactoryTest.java
@@ -40,23 +40,6 @@ import static org.junit.Assert.assertEquals;
 public class NexmarkTableSourceFactoryTest {
 
 	@Test
-	public void testCommonProperties() {
-		Map<String, String> properties = getAllOptions();
-
-		// validation for source
-		DynamicTableSource actualSource = createTableSource(properties);
-		GeneratorConfig config = new GeneratorConfig(
-			new NexmarkConfiguration(),
-			System.currentTimeMillis(),
-			1,
-			0,
-			1
-		);
-		NexmarkTableSource expectedSource = new NexmarkTableSource(config);
-		assertEquals(expectedSource, actualSource);
-	}
-
-	@Test
 	public void testCustomProperties() {
 		Map<String, String> properties = getAllOptions();
 		properties.put("rate.shape", "SQUARE");
@@ -74,6 +57,8 @@ public class NexmarkTableSourceFactoryTest {
 		properties.put("bid.hot-ratio.bidders", "5");
 		properties.put("auction.hot-ratio.sellers", "8");
 		properties.put("events.num", "100");
+		properties.put("events.base-time", "1000");
+		properties.put("events.simulation.mode", "false");
 
 		DynamicTableSource actualSource = createTableSource(properties);
 		NexmarkConfiguration nexmarkConf = new NexmarkConfiguration();
@@ -92,14 +77,14 @@ public class NexmarkTableSourceFactoryTest {
 		nexmarkConf.hotBiddersRatio = 5;
 		nexmarkConf.hotSellersRatio = 8;
 		nexmarkConf.numEvents = 100;
+		nexmarkConf.baseTime = 1000;
+		nexmarkConf.simulationMode = false;
 
 		GeneratorConfig config = new GeneratorConfig(
 			nexmarkConf,
-			System.currentTimeMillis(),
 			1,
 			nexmarkConf.numEvents,
-			1
-		);
+			1);
 		NexmarkTableSource expectedSource = new NexmarkTableSource(config);
 		assertEquals(expectedSource, actualSource);
 	}


### PR DESCRIPTION
## Background
We can regard extended-bid as the view of 

```
SELECT bid.auction, auction.seller, bid.bidder, auction.category, bid.price, bid.dateTime, bid.extra
FROM bid
JOIN ON bid.auction = auction.id;
```

The test query may be
```
SELECT
     category BIGINT
     min(dateTime) AS auctionStartTime,
     max(dateTime) AS auctionEndTime,
     sum(price) as gmv,
     avg(price) as avgPrice,
     count(distinct auction) AS total_auction,
     count(distinct bidder) AS total_bidder,
     count(distinct seller) AS total_seller,
     count(*) AS total_bid,
     '${hour}',
     '${minute}'
FROM bid
WHERE hr < ${hr} OR hr = ${hr} AND ms <= ${ms}
GROUP BY category
```

The test is used to test the performance between spark and flink when use flink/spark as pipe to transfer the data between hive. 

## Implementation Details

These options are used to generate the unlimited joined data.
* bid.extended.mode allow us to generate the joined bid.
* events.base-time allow us to specify the timestamp of the first element.
* events.simulation.mode allow us to generate as fast as we can.

We use auction id to generate the deterministic auction, which gurantees the data consistency.