### PR TITLE
Bump flink version and support eventsNum in workload

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
@@ -145,6 +145,21 @@ public class FlinkRestClient {
 		return TpsMetric.fromJson(response);
 	}
 
+	public boolean isFinished(String jobId) {
+		String url = String.format(
+			"http://%s/jobs/%s",
+			jmEndpoint,
+			jobId);
+		String response = executeAsString(url);
+		try {
+			JsonNode jsonNode = NexmarkUtils.MAPPER.readTree(response);
+			JsonNode state = jsonNode.get("state");
+			return state.asText().equalsIgnoreCase("FINISHED");
+		} catch (Exception e) {
+			throw new RuntimeException("The response is not a valid JSON string: \n" + response, e);
+		}
+	}
+
 	private void patch(String url) {
 		HttpPatch httpPatch = new HttpPatch();
 		httpPatch.setURI(URI.create(url));

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSource.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/source/NexmarkTableSource.java
@@ -86,7 +86,7 @@ public class NexmarkTableSource implements ScanTableSource {
 	@SuppressWarnings("unchecked")
 	@Override
 	public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
-		TypeInformation<RowData> outputType = (TypeInformation<RowData>) scanContext
+		TypeInformation<RowData> outputType = scanContext
 			.createTypeInformation(NEXMARK_SCHEMA.toPhysicalRowDataType());
 		NexmarkSourceFunction<RowData> sourceFunction = new NexmarkSourceFunction<>(
 			config,

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
@@ -28,12 +28,18 @@ public class Workload {
 	private final int personProportion;
 	private final int auctionProportion;
 	private final int bidProportion;
+	private final long eventsNum;
 
 	public Workload(long tps, int personProportion, int auctionProportion, int bidProportion) {
+		this(tps, personProportion, auctionProportion, bidProportion, Long.MAX_VALUE);
+	}
+
+	public Workload(long tps, int personProportion, int auctionProportion, int bidProportion, long eventsNum) {
 		this.tps = tps;
 		this.personProportion = personProportion;
 		this.auctionProportion = auctionProportion;
 		this.bidProportion = bidProportion;
+		this.eventsNum = eventsNum;
 	}
 
 	public long getTps() {
@@ -52,6 +58,10 @@ public class Workload {
 		return bidProportion;
 	}
 
+	public long getEventsNum() {
+		return eventsNum;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -60,21 +70,23 @@ public class Workload {
 		return tps == workload.tps &&
 			personProportion == workload.personProportion &&
 			auctionProportion == workload.auctionProportion &&
-			bidProportion == workload.bidProportion;
+			bidProportion == workload.bidProportion &&
+			eventsNum == workload.eventsNum;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(tps, personProportion, auctionProportion, bidProportion);
+		return Objects.hash(tps, personProportion, auctionProportion, bidProportion, eventsNum);
 	}
 
 	public String getSummaryString() {
 		return String.format(
-			"[tps=%s, percentage=bid:%s,auction:%s,person:%s]",
+			"[tps=%s, percentage=bid:%s,auction:%s,person:%s, eventsNum:%s]",
 			BenchmarkMetric.formatLongValue(tps),
 			bidProportion,
 			auctionProportion,
-			personProportion);
+			personProportion,
+			eventsNum);
 	}
 
 	@Override
@@ -84,6 +96,7 @@ public class Workload {
 			", personProportion=" + personProportion +
 			", auctionProportion=" + auctionProportion +
 			", bidProportion=" + bidProportion +
+			", eventsNum=" + eventsNum +
 			'}';
 	}
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/WorkloadSuite.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/WorkloadSuite.java
@@ -34,6 +34,7 @@ public class WorkloadSuite {
 
 	private static final String WORKLOAD_SUITE_CONF_PREFIX = "nexmark.workload.suite.";
 	private static final String TPS_CONF_SUFFIX = ".tps";
+	private static final String EVENTS_NUM_CONF_SUFFIX = ".events.num";
 
 	private final Map<String, Workload> query2Workload;
 
@@ -80,6 +81,9 @@ public class WorkloadSuite {
 			String tpsKey = WORKLOAD_SUITE_CONF_PREFIX + suiteName + TPS_CONF_SUFFIX;
 			long tps = Long.parseLong(confMap.get(tpsKey));
 
+			String eventsNumKey = WORKLOAD_SUITE_CONF_PREFIX + suiteName + EVENTS_NUM_CONF_SUFFIX;
+			long eventsNum = Long.parseLong(confMap.getOrDefault(eventsNumKey, Long.toString(Long.MAX_VALUE)));
+
 			int personProportion = NexmarkSourceOptions.PERSON_PROPORTION.defaultValue();
 			int auctionProportion = NexmarkSourceOptions.AUCTION_PROPORTION.defaultValue();
 			int bidProportion = NexmarkSourceOptions.BID_PROPORTION.defaultValue();
@@ -100,7 +104,7 @@ public class WorkloadSuite {
 					}
 				}
 			}
-			Workload load = new Workload(tps, personProportion, auctionProportion, bidProportion);
+			Workload load = new Workload(tps, personProportion, auctionProportion, bidProportion, eventsNum);
 
 			String queriesKey = WORKLOAD_SUITE_CONF_PREFIX + suiteName + ".queries";
 			List<String> queries = new ArrayList<>();

--- a/nexmark-flink/src/main/resources/queries/ddl.sql
+++ b/nexmark-flink/src/main/resources/queries/ddl.sql
@@ -39,7 +39,8 @@ CREATE TABLE nexmark (
     'next-event.rate' = '${TPS}',
     'person.proportion' = '${PERSON_PROPORTION}',
     'auction.proportion' = '${AUCTION_PROPORTION}',
-    'bid.proportion' = '${BID_PROPORTION}'
+    'bid.proportion' = '${BID_PROPORTION}',
+    'events.num' = '${EVENTS_NUM}'
 );
 
 CREATE VIEW person AS

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkTableSourceFactoryTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/source/NexmarkTableSourceFactoryTest.java
@@ -116,6 +116,7 @@ public class NexmarkTableSourceFactoryTest {
 			ObjectIdentifier.of("default", "default", "t1"),
 			new CatalogTableImpl(NexmarkTableSource.NEXMARK_SCHEMA, options, "mock source"),
 			new Configuration(),
-			NexmarkTableSourceFactoryTest.class.getClassLoader());
+			NexmarkTableSourceFactoryTest.class.getClassLoader(),
+			false);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <version>0.1-SNAPSHOT</version>
 
     <properties>
-        <flink.version>1.11.1</flink.version>
+        <flink.version>1.13-SNAPSHOT</flink.version>
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <java.version>1.8</java.version>


### PR DESCRIPTION
This PR contains 2 commits
- 8843572 Bump flink version to 1.13-SNAPSHOT
- 85842a5 Support eventsNum in workload, which can run the workload until processed specified number of events.