### PR TITLE
[Workload] Add warmup for queries

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
@@ -93,7 +93,7 @@ public class QueryRunner {
 
 	private long waitForOrJobFinish(long mills) {
 		long waited = 0L;
-		while (waited < mills && flinkRestClient.isJobRunning()) {
+		while ((mills <= 0L || waited < mills) && flinkRestClient.isJobRunning()) {
 			try {
 				Thread.sleep(100L);
 				waited += 100L;

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
@@ -18,7 +18,6 @@
 
 package com.github.nexmark.flink;
 
-import com.github.nexmark.flink.metric.BenchmarkMetric;
 import com.github.nexmark.flink.metric.FlinkRestClient;
 import com.github.nexmark.flink.metric.JobBenchmarkMetric;
 import com.github.nexmark.flink.metric.MetricReporter;
@@ -31,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,6 +65,16 @@ public class QueryRunner {
 			System.out.println("Start to run query " + queryName + " with workload " + workload.getSummaryString());
 			LOG.info("==================================================================");
 			LOG.info("Start to run query " + queryName + " with workload " + workload.getSummaryString());
+			if (!"insert_kafka".equals(queryName) && (workload.getWarmupEvents() > 0L || workload.getWarmupMills() > 0L)) {
+				System.out.println("Start the warmup for at most " + workload.getWarmupMills() + "ms and " + workload.getWarmupEvents() + " events.");
+				LOG.info("Start the warmup for at most " + workload.getWarmupMills() + "ms and " + workload.getWarmupEvents() + " events.");
+				runWarmup(workload.getWarmupTps(), workload.getWarmupEvents());
+				long waited = waitForOrJobFinish(workload.getWarmupMills());
+				if (flinkRestClient.isJobRunning()) {
+					flinkRestClient.cancelJob(flinkRestClient.getCurrentJobId());
+				}
+				LOG.info("Stop the warmup, cost " + Duration.ofMillis(waited) + ".");
+			}
 			runInternal();
 			// blocking until collect enough metrics
 			String jobId = flinkRestClient.getCurrentJobId();
@@ -79,6 +89,29 @@ public class QueryRunner {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	private long waitForOrJobFinish(long mills) {
+		long waited = 0L;
+		while (waited < mills && flinkRestClient.isJobRunning()) {
+			try {
+				Thread.sleep(100L);
+				waited += 100L;
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return waited;
+	}
+
+	private void runWarmup(long tps, long events) throws IOException {
+		Map<String, String> varsMap = initializeVarsMap();
+		varsMap.put("TPS", String.valueOf(tps));
+		if (workload.getKafkaServers() == null) {
+			varsMap.put("EVENTS_NUM", String.valueOf(events));
+		}
+		List<String> sqlLines = initializeAllSqlLines(varsMap);
+		submitSQLJob(sqlLines);
 	}
 
 	private void runInternal() throws IOException {

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -74,8 +73,8 @@ public class QueryRunner {
 				runWarmup(workload.getWarmupTps(), workload.getWarmupEvents());
 				long waited = waitForOrJobFinish(workload.getWarmupMills());
 				waited += cancelJob();
-				System.out.println("Stop the warmup, cost " + Duration.ofMillis(waited) + ".");
-				LOG.info("Stop the warmup, cost " + Duration.ofMillis(waited) + ".");
+				System.out.println("Stop the warmup, cost " + waited + "ms.");
+				LOG.info("Stop the warmup, cost " + waited + ".");
 			}
 			runInternal();
 			// blocking until collect enough metrics

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
@@ -36,9 +36,12 @@ public class Workload {
 	private final int auctionProportion;
 	private final int bidProportion;
 	private final @Nullable String kafkaServers;
+	private final long warmupMills;
+	private final long warmupTps;
+	private final long warmupEvents;
 
 	public Workload(long tps, long eventsNum, int personProportion, int auctionProportion, int bidProportion) {
-		this(tps, eventsNum, personProportion, auctionProportion, bidProportion, null);
+		this(tps, eventsNum, personProportion, auctionProportion, bidProportion, null, 0L, 0, 0);
 	}
 
 	public Workload(
@@ -47,13 +50,19 @@ public class Workload {
 			int personProportion,
 			int auctionProportion,
 			int bidProportion,
-			@Nullable String kafkaServers) {
+			@Nullable String kafkaServers,
+			long warmupMills,
+			long warmupTps,
+			long warmupEvents) {
 		this.tps = tps;
 		this.eventsNum = eventsNum;
 		this.personProportion = personProportion;
 		this.auctionProportion = auctionProportion;
 		this.bidProportion = bidProportion;
 		this.kafkaServers = kafkaServers;
+		this.warmupMills = warmupMills;
+		this.warmupTps = warmupTps;
+		this.warmupEvents = warmupEvents;
 	}
 
 	public long getTps() {
@@ -78,6 +87,18 @@ public class Workload {
 
 	public String getKafkaServers() {
 		return kafkaServers;
+	}
+
+	public long getWarmupMills() {
+		return warmupMills;
+	}
+
+	public long getWarmupTps() {
+		return warmupTps;
+	}
+
+	public long getWarmupEvents() {
+		return warmupEvents;
 	}
 
 	public void validateWorkload(Duration monitorDuration) {

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
@@ -41,7 +41,7 @@ public class Workload {
 	private final long warmupEvents;
 
 	public Workload(long tps, long eventsNum, int personProportion, int auctionProportion, int bidProportion) {
-		this(tps, eventsNum, personProportion, auctionProportion, bidProportion, null, 0L, 0, 0);
+		this(tps, eventsNum, personProportion, auctionProportion, bidProportion, null, 0L, 0L, 0L);
 	}
 
 	public Workload(

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/WorkloadSuite.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/WorkloadSuite.java
@@ -21,6 +21,7 @@ package com.github.nexmark.flink.workload;
 import org.apache.flink.configuration.Configuration;
 
 import com.github.nexmark.flink.source.NexmarkSourceOptions;
+import org.apache.flink.util.TimeUtils;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -120,7 +121,7 @@ public class WorkloadSuite {
 						"Kafka source is endless, only supports tps mode (unlimited events.num) now");
 			}
 
-			Duration warmupDuration = Duration.parse(confMap.getOrDefault(
+			Duration warmupDuration = TimeUtils.parseDuration(confMap.getOrDefault(
 					WORKLOAD_SUITE_CONF_PREFIX + suiteName + WARMUP_DURATION_SUFFIX,
 					"120s"));
 

--- a/nexmark-flink/src/main/resources/conf/nexmark.yaml
+++ b/nexmark-flink/src/main/resources/conf/nexmark.yaml
@@ -32,6 +32,9 @@ nexmark.metric.reporter.port: 9098
 nexmark.workload.suite.100m.events.num: 100000000
 nexmark.workload.suite.100m.tps: 10000000
 nexmark.workload.suite.100m.queries: "q0,q1,q2,q3,q4,q5,q7,q8,q9,q10,q11,q12,q13,q14,q15,q16,q17,q18,q19,q20,q21,q22"
+nexmark.workload.suite.100m.warmup.durartion: 120s
+nexmark.workload.suite.100m.warmup.events.num: 100000000
+nexmark.workload.suite.100m.warmup.tps: 10000000
 
 #==============================================================================
 # Benchmark workload configuration (tps, legacy mode)


### PR DESCRIPTION
At present, there is no warm-up mechanism for Nexmark. However, warming up the code in JVM is essential for stabilizing the benchmark score, especially when the query runs shortly. I capture a flame graph from Query 8 in a newly created Flink session cluster. The query runs for about 40 seconds with 100,000,000 events in a limited throughput, and the flame graph below profiles the application for the last 25 seconds:
![image](https://user-images.githubusercontent.com/2986149/154924274-085e2c6a-7db8-4eda-a820-d3234a12b7fa.png)

The benchmark result is:
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+
| Nexmark Query     | Events Num        | Cores             | Time(s)           | Cores * Time(s)   | Throughput/Cores  |
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+
|q8                 |100,000,000        |6.12               |37.686             |230.823            |433.23 K/s         |
|Total              |100,000,000        |6.125              |37.686             |230.823            |433.23 K/s         |
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+

As we can see, the C2Compiler consumes about 19% of the whole cpu usage, which is a huge impact on the benchmark results. This PR adds a warm-up for each query. It inserts an warm-up stage before each query job, submitting a same query running for a fixed period of time or consuming a fixed number of events. With this PR, we re-run the Query 8 with 120s warm-up in our setup and capture the flame graph as below:

![image](https://user-images.githubusercontent.com/2986149/154931391-f2065ded-ddb3-44f9-bcb6-d8380cb1a440.png)

And the benchmark result is:
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+
| Nexmark Query     | Events Num        | Cores             | Time(s)           | Cores * Time(s)   | Throughput/Cores  |
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+
|q8                 |100,000,000        |4.98               |39.503             |196.727            |508.32 K/s         |
|Total              |100,000,000        |4.980              |39.503             |196.727            |508.32 K/s         |
+-------------------+-------------------+-------------------+-------------------+-------------------+-------------------+

The C2Compiler consumes less CPU (19.52% -> 2.77%), leading a huge raise in the benchmark score.
