### PR TITLE
[flink] Incremental deduplication to get current job id

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/QueryRunner.java
@@ -105,7 +105,7 @@ public class QueryRunner {
 
 	private long cancelJob() {
 		long cost = 0L;
-		while (flinkRestClient.isJobRunning()) {
+		while (!flinkRestClient.isJobCancellingOrFinished()) {
 			// make sure the job is canceled.
 			flinkRestClient.cancelJob(flinkRestClient.getCurrentJobId());
 			try {

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
@@ -115,12 +115,8 @@ public class MetricReporter {
 		}
 	}
 
-	private boolean isJobRunning() {
-		return flinkRestClient.isJobRunning();
-	}
-
 	private void waitForOrJobFinish() {
-		while (isJobRunning()) {
+		while (flinkRestClient.isJobRunning()) {
 			try {
 				Thread.sleep(100L);
 			} catch (InterruptedException e) {


### PR DESCRIPTION
After the [FLINK-20195](https://issues.apache.org/jira/browse/FLINK-20195), the rest api of job brief overview (the '/jobs' GET query) returns all the job ids with its status in different order comparing to the previous version. For more details, see this change: https://github.com/apache/flink/pull/18078/files#diff-a4b690fb2c4975d25b05eb4161617af0d704a85ff7b1cad19d3c817c12f1e29cL608-R608 . To be brief, currently we get completed job id first when we query '/jobs', which will be treated as the current job id by the Nexmark Runner, based on a wrong precondition that the id of currently running job will return firstly. This PR will fix this problem, using a HashMap to record all previous job ids and identify the most recently added one as the current job id.