### PR TITLE
[flink] use ThreadLocalRandom to replace Random

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
@@ -28,7 +28,7 @@ import com.github.nexmark.flink.generator.model.BidGenerator;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -101,8 +101,6 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
     }
   }
 
-  private final Random random;
-
   /**
    * Configuration to generate events against. Note that it may be replaced by a call to {@link
    * #splitAtEventId}.
@@ -120,8 +118,6 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
     this.config = config;
     this.eventsCountSoFar = eventsCountSoFar;
     this.wallclockBaseTime = wallclockBaseTime;
-    // random generator
-    this.random = new Random();
   }
 
   /** Create a fresh generator according to {@code config}. */
@@ -198,13 +194,13 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
     Event event;
     if (rem < config.personProportion) {
       event =
-          new Event(PersonGenerator.nextPerson(newEventId, random, adjustedEventTimestamp, config));
+          new Event(PersonGenerator.nextPerson(newEventId, ThreadLocalRandom.current(), adjustedEventTimestamp, config));
     } else if (rem < config.personProportion + config.auctionProportion) {
       event =
           new Event(
-              AuctionGenerator.nextAuction(eventsCountSoFar, newEventId, random, adjustedEventTimestamp, config));
+              AuctionGenerator.nextAuction(eventsCountSoFar, newEventId, ThreadLocalRandom.current(), adjustedEventTimestamp, config));
     } else {
-      event = new Event(BidGenerator.nextBid(newEventId, random, adjustedEventTimestamp, config));
+      event = new Event(BidGenerator.nextBid(newEventId, ThreadLocalRandom.current(), adjustedEventTimestamp, config));
     }
 
     eventsCountSoFar++;

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
@@ -25,6 +25,7 @@ import com.github.nexmark.flink.model.Bid;
 
 import java.time.Instant;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.github.nexmark.flink.generator.model.StringsGenerator.nextString;
 
@@ -52,7 +53,7 @@ public class BidGenerator {
             @Override
             public Tuple2<String, String> getNewInstance(Integer channelNumber) {
               String url = getBaseUrl();
-              if (new Random().nextInt(10) > 0) {
+              if (ThreadLocalRandom.current().nextInt(10) > 0) {
                 url = url + "&channel_id=" + Math.abs(Integer.reverse(channelNumber));
               }
               return new Tuple2<>("channel-" + channelNumber, url);
@@ -105,7 +106,7 @@ public class BidGenerator {
   }
 
   private static String getBaseUrl() {
-    Random random = new Random();
+    Random random = ThreadLocalRandom.current();
     return "https://www.nexmark.com/" +
             nextString(random, 5, '_') + '/' +
             nextString(random, 5, '_') + '/' +


### PR DESCRIPTION
Background:
In flink test, nexmark's random generator becomes the hottest code. It block to analysis performance of flink. The reason is nexmark uses java.util.Random class to generate a lot of data for test. And Random class uses an atomic compareAndSwap operation to update seed value in every nextXXX invoke. 

Change:
Replace Random with more efficient ThreadLocalRandom, it keeps seed as a thread local data and avoid atomic operation. In my test, it can improve 25% in random string generator.

