### PR TITLE
Remove flink dependency from generator

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/NexmarkGenerator.java
@@ -43,7 +43,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * microseconds). The event stream is thus fully deterministic and does not depend on wallclock
  * time.
  */
-public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Serializable {
+public class NexmarkGenerator implements Iterator<NexmarkGenerator.NextEvent>, Serializable {
 
   /**
    * The next event and its various timestamps. Ordered by increasing wallclock timestamp, then
@@ -212,9 +212,8 @@ public class NexmarkGenerator implements Iterator<TimestampedValue<Event>>, Seri
   }
 
   @Override
-  public TimestampedValue<Event> next() {
-    NextEvent next = nextEvent();
-    return new TimestampedValue<>(next.event, next.eventTimestamp);
+  public NexmarkGenerator.NextEvent next() {
+    return nextEvent();
   }
 
   @Override

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java
@@ -17,12 +17,12 @@
  */
 package com.github.nexmark.flink.generator.model;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.utils.ThreadLocalCache;
 
 import com.github.nexmark.flink.generator.GeneratorConfig;
 import com.github.nexmark.flink.model.Bid;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.time.Instant;
 import java.util.Random;
 
@@ -46,18 +46,16 @@ public class BidGenerator {
   private static final String[] HOT_CHANNELS = new String[] {"Google", "Facebook", "Baidu", "Apple"};
   private static final String[] HOT_URLS = new String[] {getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl()};
 
-  private static final ThreadLocalCache<Integer, Tuple2<String, String>> CHANNEL_URL_CACHE =
-          new ThreadLocalCache<Integer, Tuple2<String, String>>(CHANNELS_NUMBER) {
-
-            @Override
-            public Tuple2<String, String> getNewInstance(Integer channelNumber) {
-              String url = getBaseUrl();
-              if (new Random().nextInt(10) > 0) {
-                url = url + "&channel_id=" + Math.abs(Integer.reverse(channelNumber));
-              }
-              return new Tuple2<>("channel-" + channelNumber, url);
-            }
-  };
+  private static final ConcurrentHashMap<Integer, Tuple2<String, String>> CHANNEL_URL_CACHE = new ConcurrentHashMap<Integer, Tuple2<String, String>>(CHANNELS_NUMBER);
+  
+  private static class Tuple2<T1,T2> {
+    public final T1 f0;
+    public final T2 f1;
+    public Tuple2(T1 f0, T2 f1){
+      this.f0 = f0;
+      this.f1 = f1;
+    }
+  }
 
   /** Generate and return a random bid with next available id. */
   public static Bid nextBid(long eventId, Random random, long timestamp, GeneratorConfig config) {
@@ -92,7 +90,7 @@ public class BidGenerator {
       channel = HOT_CHANNELS[i];
       url = HOT_URLS[i];
     } else {
-      Tuple2<String, String> channelAndUrl = CHANNEL_URL_CACHE.get(random.nextInt(CHANNELS_NUMBER));
+      Tuple2<String, String> channelAndUrl = getNextChannelAndurl(random.nextInt(CHANNELS_NUMBER));
       channel = channelAndUrl.f0;
       url = channelAndUrl.f1;
     }
@@ -111,5 +109,19 @@ public class BidGenerator {
             nextString(random, 5, '_') + '/' +
             nextString(random, 5, '_') + '/' +
             "item.htm?query=1";
+  }
+
+  private static Tuple2<String, String> getNextChannelAndurl(int channelNumber){
+    Tuple2<String, String> previousValue = CHANNEL_URL_CACHE.get(channelNumber);
+    if(previousValue == null){
+      String url = getBaseUrl();
+      if (new Random().nextInt(10) > 0) {
+        url = url + "&channel_id=" + Math.abs(Integer.reverse(channelNumber));
+      }
+      
+      CHANNEL_URL_CACHE.putIfAbsent(channelNumber, new Tuple2<String, String>("channel-" + channelNumber, url));
+    }
+
+    return CHANNEL_URL_CACHE.get(channelNumber);
   }
 }

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Auction.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Auction.java
@@ -18,10 +18,9 @@
 
 package com.github.nexmark.flink.model;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Objects;
-
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Objects;
 
 /** An auction submitted by a person. */
 public class Auction implements Serializable {
@@ -105,18 +104,18 @@ public class Auction implements Serializable {
 		return id == auction.id
 			&& initialBid == auction.initialBid
 			&& reserve == auction.reserve
-			&& Objects.equal(dateTime, auction.dateTime)
-			&& Objects.equal(expires, auction.expires)
+			&& Objects.equals(dateTime, auction.dateTime)
+			&& Objects.equals(expires, auction.expires)
 			&& seller == auction.seller
 			&& category == auction.category
-			&& Objects.equal(itemName, auction.itemName)
-			&& Objects.equal(description, auction.description)
-			&& Objects.equal(extra, auction.extra);
+			&& Objects.equals(itemName, auction.itemName)
+			&& Objects.equals(description, auction.description)
+			&& Objects.equals(extra, auction.extra);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(
+		return Objects.hash(
 			id, itemName, description, initialBid, reserve, dateTime, expires, seller, category, extra);
 	}
 }

--- a/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
+++ b/nexmark-flink/src/test/java/com/github/nexmark/flink/generator/NexmarkGeneratorTest.java
@@ -33,7 +33,7 @@ public class NexmarkGeneratorTest {
 		NexmarkGenerator generator = new NexmarkGenerator(generatorConfig);
 		int count = 0;
 		while (generator.hasNext()) {
-			Event event = generator.next().getValue();
+			Event event = generator.next().event;
 			count ++;
 			System.out.println(event);
 		}


### PR DESCRIPTION
[nexmark-flink](https://github.com/nexmark/nexmark/tree/master/nexmark-flink) has data generation classes that are useful beyond the flink benchmarks. In preparation for #35 , this PR removes flink dependency from data generation classes.