### PR TITLE
[hotfix] Correct the typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Some notable configurations including:
 - Job parallelism: 8
 - Checkpoint enabled with exactly once mode and 3 minutes interval
 - Use RocksDB state backend with incremental checkpoint enabled
-- MiniBatch optimization enabled with 2 seconds interval and 5000 rows
+- MiniBatch optimization enabled with 2 seconds interval and 50000 rows
 - Splitting distinct aggregation optimization is enabled
 
 Flink version: 1.13.


### PR DESCRIPTION
The configuration of `table.exec.mini-batch.size`: 50000
table.exec.mini-batch.size is configured in [sql-client-defaults.yaml](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/conf/sql-client-defaults.yaml#L68) to be 50000, but the README.md states that it is 5000, I think this is a typo.
