### PR TITLE
[Nexmark-40] Enable configuration in flink-conf.yaml instead of sql-client.yaml

### DIFF
--- a/nexmark-flink/src/main/resources/conf/flink-conf.yaml
+++ b/nexmark-flink/src/main/resources/conf/flink-conf.yaml
@@ -103,3 +103,9 @@ akka.framesize: 102400kB
 web.timeout: 120000
 
 classloader.resolve-order: parent-first
+
+# configuration options for adjusting and tuning table programs.
+table.exec.mini-batch.enabled: true
+table.exec.mini-batch.allow-latency: 2s
+table.exec.mini-batch.size: 50000
+table.optimizer.distinct-agg.split.enabled: true


### PR DESCRIPTION
fix: #40 
Flink configuration should be enabled in the flink-conf.yaml after the Flink-1.13 version, [this issue](https://issues.apache.org/jira/browse/FLINK-22171) updates the SQL-client documents.