### PR TITLE
[flink] disable final checkpoint by default in flink-conf.yaml

### DIFF
--- a/nexmark-flink/src/main/resources/conf/flink-conf.yaml
+++ b/nexmark-flink/src/main/resources/conf/flink-conf.yaml
@@ -109,3 +109,6 @@ table.exec.mini-batch.enabled: true
 table.exec.mini-batch.allow-latency: 2s
 table.exec.mini-batch.size: 50000
 table.optimizer.distinct-agg.split.enabled: true
+
+# disable final checkpoint to avoid test waiting for the last checkpoint complete
+execution.checkpointing.checkpoints-after-tasks-finish.enabled: false


### PR DESCRIPTION
# What is the purpose of the change
As described in [FLINK-25105](https://issues.apache.org/jira/browse/FLINK-25105), 

> In 1.15 we enabled the support of checkpoints after part of tasks were finished by default, and make tasks wait for the final checkpoint before the exit to ensure all data get committed.
> ...
> In other words, this change will block the tasks until the next checkpoint gets triggered and completed. If the checkpoint interval is long, the tasks' execution time would also be extended largely.

The feature will make the queries wait for the final checkpoint, which is represented as the query will end at a similar time (as shown in the figure). This results in significant degradation of the final result.

<img width="346" alt="image" src="https://user-images.githubusercontent.com/19743175/228761104-e6dc0b67-01d6-4473-b8be-cab992febcd9.png">


# Brief change log
* Disable waiting for the final checkpoint in benchmarks in flink-conf.yaml
