### PR TITLE
[Flink] Fix the bug of q20 and monitor duration mertic default value

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/FlinkNexmarkOptions.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/FlinkNexmarkOptions.java
@@ -37,7 +37,7 @@ public class FlinkNexmarkOptions {
 	public static final ConfigOption<Duration> METRIC_MONITOR_DURATION = ConfigOptions
 		.key("nexmark.metric.monitor.duration")
 		.durationType()
-		.defaultValue(Duration.ofMillis(Long.MAX_VALUE))
+		.defaultValue(Duration.ofNanos(Long.MAX_VALUE))
 		.withDescription("How long to monitor the metrics, default never end, " +
 			"monitor until job is finished.");
 

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/workload/Workload.java
@@ -102,7 +102,7 @@ public class Workload {
 	}
 
 	public void validateWorkload(Duration monitorDuration) {
-		boolean unboundedMonitor = monitorDuration.toMillis() == Long.MAX_VALUE;
+		boolean unboundedMonitor = monitorDuration.toNanos() == Long.MAX_VALUE;
 		if (getEventsNum() == 0) {
 			// TPS mode
 			Preconditions.checkArgument(

--- a/nexmark-flink/src/main/resources/queries/q20.sql
+++ b/nexmark-flink/src/main/resources/queries/q20.sql
@@ -5,7 +5,7 @@
 -- Illustrates a filter join.
 -- -------------------------------------------------------------------------------------------------
 
-CREATE TABLE discard_sink (
+CREATE TABLE nexmark_q20 (
     auction  BIGINT,
     bidder  BIGINT,
     price  BIGINT,


### PR DESCRIPTION
Fix the bug of q20 and `nexmark.metric.monitor.duration` default value

![image](https://github.com/nexmark/nexmark/assets/17698589/cb7026b1-ff8f-4bad-ac50-c4fcefd59199)
