### PR TITLE
Fixed minor bug in q7

### DIFF
--- a/nexmark-flink/src/main/resources/queries/q7.sql
+++ b/nexmark-flink/src/main/resources/queries/q7.sql
@@ -19,7 +19,7 @@ CREATE TABLE nexmark_q7 (
 );
 
 INSERT INTO nexmark_q7
-SELECT B.auction, B.price, B.bidder, B.dateTime, B.extra
+SELECT B.auction, B.bidder, B.price, B.dateTime, B.extra
 from bid B
 JOIN (
   SELECT MAX(price) AS maxprice, window_end as dateTime


### PR DESCRIPTION
There was discrepancy in `nexmark_q7` schema and the select `statement`. `bidder` was exchanged with `price`, but since there both of their types are `BIGINT` this didn't cause any runtime errors. This could be a minor nuisance for anyone trying to go through the output of the query :-).