### PR TITLE
[Flink] Rename dateTime to customTime to adapt calcite 1.34.0

### DIFF
--- a/nexmark-flink/src/main/resources/queries/ddl_gen.sql
+++ b/nexmark-flink/src/main/resources/queries/ddl_gen.sql
@@ -7,7 +7,7 @@ CREATE TABLE datagen (
         creditCard  VARCHAR,
         city  VARCHAR,
         state  VARCHAR,
-        dateTime TIMESTAMP(3),
+        customTime TIMESTAMP(3),
         extra  VARCHAR>,
     auction ROW<
         id  BIGINT,
@@ -15,7 +15,7 @@ CREATE TABLE datagen (
         description  VARCHAR,
         initialBid  BIGINT,
         reserve  BIGINT,
-        dateTime  TIMESTAMP(3),
+        customTime  TIMESTAMP(3),
         expires  TIMESTAMP(3),
         seller  BIGINT,
         category  BIGINT,
@@ -26,15 +26,15 @@ CREATE TABLE datagen (
         price  BIGINT,
         channel  VARCHAR,
         url  VARCHAR,
-        dateTime  TIMESTAMP(3),
+        customTime  TIMESTAMP(3),
         extra  VARCHAR>,
-    dateTime AS
+    customTime AS
         CASE
-            WHEN event_type = 0 THEN person.dateTime
-            WHEN event_type = 1 THEN auction.dateTime
-            ELSE bid.dateTime
+            WHEN event_type = 0 THEN person.customTime
+            WHEN event_type = 1 THEN auction.customTime
+            ELSE bid.customTime
         END,
-    WATERMARK FOR dateTime AS dateTime - INTERVAL '4' SECOND
+    WATERMARK FOR customTime AS customTime - INTERVAL '4' SECOND
 ) WITH (
     'connector' = 'nexmark',
     'first-event.rate' = '${TPS}',

--- a/nexmark-flink/src/main/resources/queries/ddl_kafka.sql
+++ b/nexmark-flink/src/main/resources/queries/ddl_kafka.sql
@@ -7,7 +7,7 @@ CREATE TABLE kafka (
         creditCard  VARCHAR,
         city  VARCHAR,
         state  VARCHAR,
-        dateTime TIMESTAMP(3),
+        customTime TIMESTAMP(3),
         extra  VARCHAR>,
     auction ROW<
         id  BIGINT,
@@ -15,7 +15,7 @@ CREATE TABLE kafka (
         description  VARCHAR,
         initialBid  BIGINT,
         reserve  BIGINT,
-        dateTime  TIMESTAMP(3),
+        customTime  TIMESTAMP(3),
         expires  TIMESTAMP(3),
         seller  BIGINT,
         category  BIGINT,
@@ -26,15 +26,15 @@ CREATE TABLE kafka (
         price  BIGINT,
         channel  VARCHAR,
         url  VARCHAR,
-        dateTime  TIMESTAMP(3),
+        customTime  TIMESTAMP(3),
         extra  VARCHAR>,
-    dateTime AS
+    customTime AS
         CASE
-            WHEN event_type = 0 THEN person.dateTime
-            WHEN event_type = 1 THEN auction.dateTime
-            ELSE bid.dateTime
+            WHEN event_type = 0 THEN person.customTime
+            WHEN event_type = 1 THEN auction.customTime
+            ELSE bid.customTime
         END,
-    WATERMARK FOR dateTime AS dateTime - INTERVAL '4' SECOND
+    WATERMARK FOR customTime AS customTime - INTERVAL '4' SECOND
 ) WITH (
     'connector' = 'kafka',
     'topic' = 'nexmark',

--- a/nexmark-flink/src/main/resources/queries/ddl_views.sql
+++ b/nexmark-flink/src/main/resources/queries/ddl_views.sql
@@ -6,7 +6,7 @@ SELECT
     person.creditCard,
     person.city,
     person.state,
-    dateTime,
+    customTime,
     person.extra
 FROM ${NEXMARK_TABLE} WHERE event_type = 0;
 
@@ -17,7 +17,7 @@ SELECT
     auction.description,
     auction.initialBid,
     auction.reserve,
-    dateTime,
+    customTime,
     auction.expires,
     auction.seller,
     auction.category,
@@ -31,6 +31,6 @@ SELECT
     bid.price,
     bid.channel,
     bid.url,
-    dateTime,
+    customTime,
     bid.extra
 FROM ${NEXMARK_TABLE} WHERE event_type = 2;

--- a/nexmark-flink/src/main/resources/queries/q0.sql
+++ b/nexmark-flink/src/main/resources/queries/q0.sql
@@ -9,11 +9,11 @@ CREATE TABLE nexmark_q0 (
   auction  BIGINT,
   bidder  BIGINT,
   price  BIGINT,
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   extra  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
 );
 
 INSERT INTO nexmark_q0
-SELECT auction, bidder, price, dateTime, extra FROM bid;
+SELECT auction, bidder, price, customTime, extra FROM bid;

--- a/nexmark-flink/src/main/resources/queries/q1.sql
+++ b/nexmark-flink/src/main/resources/queries/q1.sql
@@ -8,7 +8,7 @@ CREATE TABLE nexmark_q1 (
   auction  BIGINT,
   bidder  BIGINT,
   price  DECIMAL(23, 3),
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   extra  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
@@ -19,6 +19,6 @@ SELECT
     auction,
     bidder,
     0.908 * price as price, -- convert dollar to euro
-    dateTime,
+    customTime,
     extra
 FROM bid;

--- a/nexmark-flink/src/main/resources/queries/q10.sql
+++ b/nexmark-flink/src/main/resources/queries/q10.sql
@@ -10,7 +10,7 @@ CREATE TABLE nexmark_q10 (
   auction  BIGINT,
   bidder  BIGINT,
   price  BIGINT,
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   extra  VARCHAR,
   dt STRING,
   hm STRING
@@ -27,5 +27,5 @@ CREATE TABLE nexmark_q10 (
 );
 
 INSERT INTO nexmark_q10
-SELECT auction, bidder, price, dateTime, extra, DATE_FORMAT(dateTime, 'yyyy-MM-dd'), DATE_FORMAT(dateTime, 'HH:mm')
+SELECT auction, bidder, price, customTime, extra, DATE_FORMAT(customTime, 'yyyy-MM-dd'), DATE_FORMAT(customTime, 'HH:mm')
 FROM bid;

--- a/nexmark-flink/src/main/resources/queries/q11.sql
+++ b/nexmark-flink/src/main/resources/queries/q11.sql
@@ -20,7 +20,7 @@ INSERT INTO nexmark_q11
 SELECT
     B.bidder,
     count(*) as bid_count,
-    SESSION_START(B.dateTime, INTERVAL '10' SECOND) as starttime,
-    SESSION_END(B.dateTime, INTERVAL '10' SECOND) as endtime
+    SESSION_START(B.customTime, INTERVAL '10' SECOND) as starttime,
+    SESSION_END(B.customTime, INTERVAL '10' SECOND) as endtime
 FROM bid B
-GROUP BY B.bidder, SESSION(B.dateTime, INTERVAL '10' SECOND);
+GROUP BY B.bidder, SESSION(B.customTime, INTERVAL '10' SECOND);

--- a/nexmark-flink/src/main/resources/queries/q13.sql
+++ b/nexmark-flink/src/main/resources/queries/q13.sql
@@ -18,7 +18,7 @@ CREATE TABLE nexmark_q13 (
   auction  BIGINT,
   bidder  BIGINT,
   price  BIGINT,
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   `value`  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
@@ -29,7 +29,7 @@ SELECT
     B.auction,
     B.bidder,
     B.price,
-    B.dateTime,
+    B.customTime,
     S.`value`
 FROM (SELECT *, PROCTIME() as p_time FROM bid) B
 JOIN side_input FOR SYSTEM_TIME AS OF B.p_time AS S

--- a/nexmark-flink/src/main/resources/queries/q14.sql
+++ b/nexmark-flink/src/main/resources/queries/q14.sql
@@ -12,7 +12,7 @@ CREATE TABLE nexmark_q14 (
     bidder BIGINT,
     price  DECIMAL(23, 3),
     bidTimeType VARCHAR,
-    dateTime TIMESTAMP(3),
+    customTime TIMESTAMP(3),
     extra VARCHAR,
     c_counts BIGINT
 ) WITH (
@@ -25,11 +25,11 @@ SELECT
     bidder,
     0.908 * price as price,
     CASE
-        WHEN HOUR(dateTime) >= 8 AND HOUR(dateTime) <= 18 THEN 'dayTime'
-        WHEN HOUR(dateTime) <= 6 OR HOUR(dateTime) >= 20 THEN 'nightTime'
+        WHEN HOUR(customTime) >= 8 AND HOUR(customTime) <= 18 THEN 'dayTime'
+        WHEN HOUR(customTime) <= 6 OR HOUR(customTime) >= 20 THEN 'nightTime'
         ELSE 'otherTime'
     END AS bidTimeType,
-    dateTime,
+    customTime,
     extra,
     count_char(extra, 'c') AS c_counts
 FROM bid

--- a/nexmark-flink/src/main/resources/queries/q15.sql
+++ b/nexmark-flink/src/main/resources/queries/q15.sql
@@ -25,7 +25,7 @@ CREATE TABLE nexmark_q15 (
 
 INSERT INTO nexmark_q15
 SELECT
-     DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+     DATE_FORMAT(customTime, 'yyyy-MM-dd') as `day`,
      count(*) AS total_bids,
      count(*) filter (where price < 10000) AS rank1_bids,
      count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -39,4 +39,4 @@ SELECT
      count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
      count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
 FROM bid
-GROUP BY DATE_FORMAT(dateTime, 'yyyy-MM-dd');
+GROUP BY DATE_FORMAT(customTime, 'yyyy-MM-dd');

--- a/nexmark-flink/src/main/resources/queries/q16.sql
+++ b/nexmark-flink/src/main/resources/queries/q16.sql
@@ -28,8 +28,8 @@ CREATE TABLE nexmark_q16 (
 INSERT INTO nexmark_q16
 SELECT
     channel,
-    DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
-    max(DATE_FORMAT(dateTime, 'HH:mm')) as `minute`,
+    DATE_FORMAT(customTime, 'yyyy-MM-dd') as `day`,
+    max(DATE_FORMAT(customTime, 'HH:mm')) as `minute`,
     count(*) AS total_bids,
     count(*) filter (where price < 10000) AS rank1_bids,
     count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -43,4 +43,4 @@ SELECT
     count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
     count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
 FROM bid
-GROUP BY channel, DATE_FORMAT(dateTime, 'yyyy-MM-dd');
+GROUP BY channel, DATE_FORMAT(customTime, 'yyyy-MM-dd');

--- a/nexmark-flink/src/main/resources/queries/q17.sql
+++ b/nexmark-flink/src/main/resources/queries/q17.sql
@@ -23,7 +23,7 @@ CREATE TABLE nexmark_q17 (
 INSERT INTO nexmark_q17
 SELECT
      auction,
-     DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+     DATE_FORMAT(customTime, 'yyyy-MM-dd') as `day`,
      count(*) AS total_bids,
      count(*) filter (where price < 10000) AS rank1_bids,
      count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -33,4 +33,4 @@ SELECT
      avg(price) AS avg_price,
      sum(price) AS sum_price
 FROM bid
-GROUP BY auction, DATE_FORMAT(dateTime, 'yyyy-MM-dd');
+GROUP BY auction, DATE_FORMAT(customTime, 'yyyy-MM-dd');

--- a/nexmark-flink/src/main/resources/queries/q18.sql
+++ b/nexmark-flink/src/main/resources/queries/q18.sql
@@ -11,14 +11,14 @@ CREATE TABLE nexmark_q18 (
     price  BIGINT,
     channel  VARCHAR,
     url  VARCHAR,
-    dateTime  TIMESTAMP(3),
+    customTime  TIMESTAMP(3),
     extra  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
 );
 
 INSERT INTO nexmark_q18
-SELECT auction, bidder, price, channel, url, dateTime, extra
- FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY dateTime DESC) AS rank_number
+SELECT auction, bidder, price, channel, url, customTime, extra
+ FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY customTime DESC) AS rank_number
        FROM bid)
  WHERE rank_number <= 1;

--- a/nexmark-flink/src/main/resources/queries/q19.sql
+++ b/nexmark-flink/src/main/resources/queries/q19.sql
@@ -11,7 +11,7 @@ CREATE TABLE nexmark_q19 (
     price  BIGINT,
     channel  VARCHAR,
     url  VARCHAR,
-    dateTime  TIMESTAMP(3),
+    customTime  TIMESTAMP(3),
     extra  VARCHAR,
     rank_number  BIGINT
 ) WITH (

--- a/nexmark-flink/src/main/resources/queries/q20.sql
+++ b/nexmark-flink/src/main/resources/queries/q20.sql
@@ -11,14 +11,14 @@ CREATE TABLE nexmark_q20 (
     price  BIGINT,
     channel  VARCHAR,
     url  VARCHAR,
-    bid_dateTime  TIMESTAMP(3),
+    bid_customTime  TIMESTAMP(3),
     bid_extra  VARCHAR,
 
     itemName  VARCHAR,
     description  VARCHAR,
     initialBid  BIGINT,
     reserve  BIGINT,
-    auction_dateTime  TIMESTAMP(3),
+    auction_customTime  TIMESTAMP(3),
     expires  TIMESTAMP(3),
     seller  BIGINT,
     category  BIGINT,
@@ -29,8 +29,8 @@ CREATE TABLE nexmark_q20 (
 
 INSERT INTO nexmark_q20
 SELECT
-    auction, bidder, price, channel, url, B.dateTime, B.extra,
-    itemName, description, initialBid, reserve, A.dateTime, expires, seller, category, A.extra
+    auction, bidder, price, channel, url, B.customTime, B.extra,
+    itemName, description, initialBid, reserve, A.customTime, expires, seller, category, A.extra
 FROM
     bid AS B INNER JOIN auction AS A on B.auction = A.id
 WHERE A.category = 10;

--- a/nexmark-flink/src/main/resources/queries/q4.sql
+++ b/nexmark-flink/src/main/resources/queries/q4.sql
@@ -19,7 +19,7 @@ SELECT
 FROM (
     SELECT MAX(B.price) AS final, A.category
     FROM auction A, bid B
-    WHERE A.id = B.auction AND B.dateTime BETWEEN A.dateTime AND A.expires
+    WHERE A.id = B.auction AND B.customTime BETWEEN A.customTime AND A.expires
     GROUP BY A.id, A.category
 ) Q
 GROUP BY Q.category;

--- a/nexmark-flink/src/main/resources/queries/q5.sql
+++ b/nexmark-flink/src/main/resources/queries/q5.sql
@@ -25,7 +25,7 @@ SELECT AuctionBids.auction, AuctionBids.num
      window_start AS starttime,
      window_end AS endtime
      FROM TABLE(
-             HOP(TABLE bid, DESCRIPTOR(dateTime), INTERVAL '2' SECOND, INTERVAL '10' SECOND))
+             HOP(TABLE bid, DESCRIPTOR(customTime), INTERVAL '2' SECOND, INTERVAL '10' SECOND))
      GROUP BY auction, window_start, window_end
  ) AS AuctionBids
  JOIN (
@@ -39,7 +39,7 @@ SELECT AuctionBids.auction, AuctionBids.num
        window_start AS starttime,
        window_end AS endtime
      FROM TABLE(
-                HOP(TABLE bid, DESCRIPTOR(dateTime), INTERVAL '2' SECOND, INTERVAL '10' SECOND))
+                HOP(TABLE bid, DESCRIPTOR(customTime), INTERVAL '2' SECOND, INTERVAL '10' SECOND))
      GROUP BY auction, window_start, window_end
      ) AS CountBids
    GROUP BY CountBids.starttime, CountBids.endtime

--- a/nexmark-flink/src/main/resources/queries/q6.sql
+++ b/nexmark-flink/src/main/resources/queries/q6.sql
@@ -18,13 +18,13 @@ INSERT INTO nexmark_q6
 SELECT
     Q.seller,
     AVG(Q.price) OVER
-        (PARTITION BY Q.seller ORDER BY Q.dateTime ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+        (PARTITION BY Q.seller ORDER BY Q.customTime ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
 FROM (
     SELECT *, ROW_NUMBER() OVER (PARTITION BY A.id, A.seller ORDER BY B.price DESC) AS rownum
-    FROM (SELECT A.id, A.seller, B.price, B.dateTime
+    FROM (SELECT A.id, A.seller, B.price, B.customTime
         FROM auction AS A,
             bid AS B
         WHERE A.id = B.auction
-            and B.dateTime between A.dateTime and A.expires)
+            and B.customTime between A.customTime and A.expires)
     WHERE rownum <= 1
 ) AS Q;

--- a/nexmark-flink/src/main/resources/queries/q7.sql
+++ b/nexmark-flink/src/main/resources/queries/q7.sql
@@ -12,20 +12,20 @@ CREATE TABLE nexmark_q7 (
   auction  BIGINT,
   bidder  BIGINT,
   price  BIGINT,
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   extra  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
 );
 
 INSERT INTO nexmark_q7
-SELECT B.auction, B.price, B.bidder, B.dateTime, B.extra
+SELECT B.auction, B.price, B.bidder, B.customTime, B.extra
 from bid B
 JOIN (
-  SELECT MAX(price) AS maxprice, window_end as dateTime
+  SELECT MAX(price) AS maxprice, window_end as customTime
   FROM TABLE(
-          TUMBLE(TABLE bid, DESCRIPTOR(dateTime), INTERVAL '10' SECOND))
+          TUMBLE(TABLE bid, DESCRIPTOR(customTime), INTERVAL '10' SECOND))
   GROUP BY window_start, window_end
 ) B1
 ON B.price = B1.maxprice
-WHERE B.dateTime BETWEEN B1.dateTime  - INTERVAL '10' SECOND AND B1.dateTime;
+WHERE B.customTime BETWEEN B1.customTime  - INTERVAL '10' SECOND AND B1.customTime;

--- a/nexmark-flink/src/main/resources/queries/q8.sql
+++ b/nexmark-flink/src/main/resources/queries/q8.sql
@@ -23,7 +23,7 @@ FROM (
         window_start AS starttime,
         window_end AS endtime
   FROM TABLE(
-            TUMBLE(TABLE person, DESCRIPTOR(dateTime), INTERVAL '10' SECOND))
+            TUMBLE(TABLE person, DESCRIPTOR(customTime), INTERVAL '10' SECOND))
   GROUP BY id, name, window_start, window_end
 ) P
 JOIN (
@@ -31,7 +31,7 @@ JOIN (
         window_start AS starttime,
         window_end AS endtime
   FROM TABLE(
-        TUMBLE(TABLE auction, DESCRIPTOR(dateTime), INTERVAL '10' SECOND))
+        TUMBLE(TABLE auction, DESCRIPTOR(customTime), INTERVAL '10' SECOND))
   GROUP BY seller, window_start, window_end
 ) A
 ON P.id = A.seller AND P.starttime = A.starttime AND P.endtime = A.endtime;

--- a/nexmark-flink/src/main/resources/queries/q9.sql
+++ b/nexmark-flink/src/main/resources/queries/q9.sql
@@ -10,7 +10,7 @@ CREATE TABLE nexmark_q9 (
   description  VARCHAR,
   initialBid  BIGINT,
   reserve  BIGINT,
-  dateTime  TIMESTAMP(3),
+  customTime  TIMESTAMP(3),
   expires  TIMESTAMP(3),
   seller  BIGINT,
   category  BIGINT,
@@ -18,7 +18,7 @@ CREATE TABLE nexmark_q9 (
   auction  BIGINT,
   bidder  BIGINT,
   price  BIGINT,
-  bid_dateTime  TIMESTAMP(3),
+  bid_customTime  TIMESTAMP(3),
   bid_extra  VARCHAR
 ) WITH (
   'connector' = 'blackhole'
@@ -26,12 +26,12 @@ CREATE TABLE nexmark_q9 (
 
 INSERT INTO nexmark_q9
 SELECT
-    id, itemName, description, initialBid, reserve, dateTime, expires, seller, category, extra,
-    auction, bidder, price, bid_dateTime, bid_extra
+    id, itemName, description, initialBid, reserve, customTime, expires, seller, category, extra,
+    auction, bidder, price, bid_customTime, bid_extra
 FROM (
-   SELECT A.*, B.auction, B.bidder, B.price, B.dateTime AS bid_dateTime, B.extra AS bid_extra,
-     ROW_NUMBER() OVER (PARTITION BY A.id ORDER BY B.price DESC, B.dateTime ASC) AS rownum
+   SELECT A.*, B.auction, B.bidder, B.price, B.customTime AS bid_customTime, B.extra AS bid_extra,
+     ROW_NUMBER() OVER (PARTITION BY A.id ORDER BY B.price DESC, B.customTime ASC) AS rownum
    FROM auction A, bid B
-   WHERE A.id = B.auction AND B.dateTime BETWEEN A.dateTime AND A.expires
+   WHERE A.id = B.auction AND B.customTime BETWEEN A.customTime AND A.expires
 )
 WHERE rownum <= 1;


### PR DESCRIPTION
The Apache calcite in Flink has upgraded to 1.34.0 (https://issues.apache.org/jira/browse/FLINK-31836), `dateTime` is treated as a keyword. This PR renames `dateTime` field to `customTime` in SQL scripts to avoid the conflit.

![image](https://github.com/user-attachments/assets/016c1aef-f535-49ed-b58c-264527e78731)
