### PR TITLE
[Flink] Add multi-way join query

### DIFF
--- a/nexmark-flink/src/main/resources/conf/nexmark.yaml
+++ b/nexmark-flink/src/main/resources/conf/nexmark.yaml
@@ -31,7 +31,7 @@ nexmark.metric.reporter.port: 9098
 
 nexmark.workload.suite.100m.events.num: 100000000
 nexmark.workload.suite.100m.tps: 10000000
-nexmark.workload.suite.100m.queries: "q0,q1,q2,q3,q4,q5,q7,q8,q9,q10,q11,q12,q13,q14,q15,q16,q17,q18,q19,q20,q21,q22"
+nexmark.workload.suite.100m.queries: "q0,q1,q2,q3,q4,q5,q7,q8,q9,q10,q11,q12,q13,q14,q15,q16,q17,q18,q19,q20,q21,q22,q23"
 nexmark.workload.suite.100m.queries.cep: "q0,q1,q2,q3"
 nexmark.workload.suite.100m.warmup.duration: 120s
 nexmark.workload.suite.100m.warmup.events.num: 100000000

--- a/nexmark-flink/src/main/resources/queries/q23.sql
+++ b/nexmark-flink/src/main/resources/queries/q23.sql
@@ -1,0 +1,66 @@
+-- -------------------------------------------------------------------------------------------------
+-- Query 23: Expand bid with person and auction (Not in original suite)
+-- -------------------------------------------------------------------------------------------------
+-- Find all bids made by a person who has also listed an item for auction
+-- Illustrates a multi-way join.
+-- -------------------------------------------------------------------------------------------------
+
+CREATE TABLE nexmark_q23
+(
+    bidder           BIGINT,
+    price            BIGINT,
+    channel          VARCHAR,
+    url              VARCHAR,
+    bid_extra        VARCHAR,
+
+    person_id       BIGINT,
+    name             VARCHAR,
+    emailAddress     VARCHAR,
+    creditCard       VARCHAR,
+    city             VARCHAR,
+    state            VARCHAR,
+    person_extra     VARCHAR,
+
+    itemName         VARCHAR,
+    description      VARCHAR,
+    initialBid       BIGINT,
+    reserve          BIGINT,
+    auction_dateTime TIMESTAMP(3),
+    expires          TIMESTAMP(3),
+    seller           BIGINT,
+    category         BIGINT,
+    auction_extra    VARCHAR
+) WITH (
+      'connector' = 'blackhole'
+      );
+
+INSERT INTO nexmark_q23
+SELECT bidder,
+       price,
+       channel,
+       url,
+       B.extra    AS bid_extra,
+
+       P.id       AS person_id,
+       name,
+       emailAddress,
+       creditCard,
+       city,
+       state,
+       P.extra    AS person_extra,
+       itemName,
+
+       description,
+       initialBid,
+       reserve,
+       A.dateTime AS auction_dateTime,
+       expires,
+       seller,
+       category,
+       A.extra    AS auction_extra
+FROM bid B
+         JOIN
+     person P ON P.id = B.bidder
+         JOIN
+     auction A ON A.seller = B.bidder;
+


### PR DESCRIPTION
This PR implements the proposal of https://github.com/nexmark/nexmark/issues/69.

---

The new query, q23, performs a multi-way join between the bid, person, and auction tables. The goal is to identify all bids made by a person who has also listed an item for auction.

###  Query Definition

```sql
INSERT INTO nexmark_q23
SELECT bidder,
       price,
       channel,
       url,
       B.extra    AS bid_extra,

       P.id       AS person_id,
       name,
       emailAddress,
       creditCard,
       city,
       state,
       P.extra    AS person_extra,
       itemName,

       description,
       initialBid,
       reserve,
       A.dateTime AS auction_dateTime,
       expires,
       seller,
       category,
       A.extra    AS auction_extra
FROM bid B
JOIN person P ON P.id = B.bidder
JOIN auction A ON A.seller = B.bidder;
```
